### PR TITLE
Fix IsCurrentPlayableCompleted

### DIFF
--- a/Assets/AnimationMixer/AnimationClipOutput.cs
+++ b/Assets/AnimationMixer/AnimationClipOutput.cs
@@ -17,6 +17,7 @@ namespace UPlayable.AnimationMixer
             m_model = new AnimationOutputModel
             {
                 IsAnimatorPlayable = false,
+                ClipLooped = ToClip != null ? ToClip.isLooping : false,
                 ClipLength = ToClip != null ? ToClip.length : -1,
                 OutputTargetWeight = TransitionSetting.OutputTargetWeight,
                 FadeInTime = TransitionSetting.FadeInTime,

--- a/Assets/AnimationMixer/AnimationMixerManager.cs
+++ b/Assets/AnimationMixer/AnimationMixerManager.cs
@@ -162,7 +162,6 @@ namespace UPlayable.AnimationMixer
             if (m_hasStatic)
                 return false;
 
-            Debug.Log(m_layeredPlayablesMap[CurrentPlayableIdInLayer].Playable.IsDone() && !m_layeredPlayablesMap[CurrentPlayableIdInLayer].ClipLooped);
             return m_layeredPlayablesMap[CurrentPlayableIdInLayer].Playable.IsDone() && !m_layeredPlayablesMap[CurrentPlayableIdInLayer].ClipLooped;
         }
 

--- a/Assets/AnimationMixer/AnimationMixerManager.cs
+++ b/Assets/AnimationMixer/AnimationMixerManager.cs
@@ -11,6 +11,7 @@ namespace UPlayable.AnimationMixer
     public struct AnimationOutputModel
     {
         public bool IsAnimatorPlayable;
+        public bool ClipLooped;
         public float ClipLength;
         public float OutputTargetWeight;
         public float FadeInTime;
@@ -41,6 +42,7 @@ namespace UPlayable.AnimationMixer
         public float ExitTime;
         public int OccupiedInputIndex;
         public bool IsAnimatorPlayable;
+        public bool ClipLooped;
         public float ClipLength;
         public float BaseSpeed;
     }
@@ -78,6 +80,7 @@ namespace UPlayable.AnimationMixer
                 ExitTime = model.ExitTime,
                 Type = PlayableInputType.Static,
                 OccupiedInputIndex = m_layeredPlayables.Count,
+                ClipLooped = model.ClipLooped,
                 ClipLength = model.ClipLength,
                 IsAnimatorPlayable = model.IsAnimatorPlayable,
                 BaseSpeed = model.Speed,
@@ -109,6 +112,7 @@ namespace UPlayable.AnimationMixer
                     TargetWeight = model.OutputTargetWeight,
                     FadeDuration = model.FadeInTime,
                     FixedTimeOffset = model.FixedTimeOffset,
+                    ClipLooped = model.ClipLooped,
                     ClipLength = model.ClipLength,
                     IsAnimatorPlayable = model.IsAnimatorPlayable,
                     ExitTime = model.ExitTime,
@@ -144,7 +148,10 @@ namespace UPlayable.AnimationMixer
             }
 
             m_layeredPlayablesMap[id].Playable.SetSpeed(m_layeredPlayablesMap[id].BaseSpeed);
-            m_layeredPlayablesMap[id].Playable.SetDuration(m_layeredPlayablesMap[id].ClipLength);
+
+            if(!m_layeredPlayablesMap[CurrentPlayableIdInLayer].ClipLooped)
+                m_layeredPlayablesMap[id].Playable.SetDuration(m_layeredPlayablesMap[id].ClipLength);
+
             m_remainExitTime = m_layeredPlayablesMap[id].ExitTime;
         }
 
@@ -154,7 +161,9 @@ namespace UPlayable.AnimationMixer
                 return true;
             if (m_hasStatic)
                 return false;
-            return m_layeredPlayablesMap[CurrentPlayableIdInLayer].Playable.IsDone();
+
+            Debug.Log(m_layeredPlayablesMap[CurrentPlayableIdInLayer].Playable.IsDone() && !m_layeredPlayablesMap[CurrentPlayableIdInLayer].ClipLooped);
+            return m_layeredPlayablesMap[CurrentPlayableIdInLayer].Playable.IsDone() && !m_layeredPlayablesMap[CurrentPlayableIdInLayer].ClipLooped;
         }
 
         public bool IsCurrentPlaying(int id)

--- a/Assets/Examples/Scenes/9_FPS_Speed_Compare.unity
+++ b/Assets/Examples/Scenes/9_FPS_Speed_Compare.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028334, g: 0.2257134, b: 0.30692226, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -149,6 +149,7 @@ Transform:
   m_LocalRotation: {x: -0.028132368, y: -0.03407927, z: -0.0024114775, w: 0.9990202}
   m_LocalPosition: {x: -0.015907401, y: 0.00016659354, z: -0.00086091814}
   m_LocalScale: {x: 1.0000031, y: 1.0000023, z: 1.000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 441822649}
   m_Father: {fileID: 2059566617}
@@ -180,6 +181,7 @@ Transform:
   m_LocalRotation: {x: 0.056542926, y: 0.7048425, z: -0.056542926, w: 0.7048425}
   m_LocalPosition: {x: -0.16301435, y: 9.7699626e-17, z: -4.0733682e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1158576495}
   m_RootOrder: 0
@@ -210,6 +212,7 @@ Transform:
   m_LocalRotation: {x: -0.4967837, y: 0.50319576, z: 0.4967837, w: 0.50319576}
   m_LocalPosition: {x: -0.08766683, y: -0.0003044751, z: 0.00000001784587}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1836277122}
   - {fileID: 1134708425}
@@ -243,6 +246,7 @@ Transform:
   m_LocalRotation: {x: -0.4967837, y: 0.50319576, z: 0.4967837, w: 0.50319576}
   m_LocalPosition: {x: -0.08766683, y: -0.0003044751, z: 0.00000001784587}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2124587144}
   - {fileID: 283266665}
@@ -276,6 +280,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 531855293}
   m_Father: {fileID: 283419386}
@@ -312,6 +317,7 @@ Transform:
   m_LocalRotation: {x: 0.06180407, y: -0.113891736, z: -0.0007837494, w: 0.9915686}
   m_LocalPosition: {x: -0.021074723, y: -0.00070411974, z: -0.0032540236}
   m_LocalScale: {x: 1.0000017, y: 1.0000018, z: 1.0000014}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1816503941}
   m_RootOrder: 0
@@ -342,6 +348,7 @@ Transform:
   m_LocalRotation: {x: 0.0022216337, y: 0.033948284, z: 0.021045804, w: 0.9991995}
   m_LocalPosition: {x: -0.14191042, y: -5.1481587e-17, z: -6.520502e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 366342028}
   m_Father: {fileID: 1922074311}
@@ -373,6 +380,7 @@ Transform:
   m_LocalRotation: {x: -0.002221635, y: -0.033948217, z: 0.021046568, w: 0.9991995}
   m_LocalPosition: {x: -0.14191027, y: 3.7508402e-17, z: 3.2530684e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 574239494}
   m_Father: {fileID: 1329599035}
@@ -405,6 +413,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1311595006}
   m_RootOrder: 12
@@ -420,6 +429,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -503,6 +513,7 @@ Transform:
   m_LocalRotation: {x: -0.000000008911413, y: 0.99850297, z: -0.05469786, w: -0.00000016267678}
   m_LocalPosition: {x: 0.1, y: 1.3677425, z: 2.6517928}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1912998594}
   m_RootOrder: 4
@@ -533,6 +544,7 @@ Transform:
   m_LocalRotation: {x: 0.99590546, y: -0.01934041, z: -0.041608024, w: -0.07789138}
   m_LocalPosition: {x: -0.07745903, y: 0.024773534, z: 0.02387737}
   m_LocalScale: {x: 1.0000012, y: 1.0000013, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 731264708}
   m_Father: {fileID: 617037369}
@@ -564,6 +576,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.16287886, y: 0.000000027959265, z: 0.000000003748803}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 688130931}
   m_RootOrder: 0
@@ -594,6 +607,7 @@ Transform:
   m_LocalRotation: {x: -0.00012399502, y: 0.00052538066, z: 0.00273948, w: 0.9999961}
   m_LocalPosition: {x: -0.11597685, y: 9.7699626e-17, z: 1.7208457e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1885940304}
   m_Father: {fileID: 1358079477}
@@ -625,6 +639,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 563286634}
   m_Father: {fileID: 337441687}
@@ -657,6 +672,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1896147211}
   - {fileID: 1604956581}
@@ -761,6 +777,7 @@ Transform:
   m_LocalRotation: {x: 0.9944477, y: 0.028325185, z: -0.06578186, w: -0.077098854}
   m_LocalPosition: {x: -0.07734096, y: 0.004360036, z: 0.024110846}
   m_LocalScale: {x: 1.0000012, y: 1.0000014, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2037545153}
   m_Father: {fileID: 1966244813}
@@ -792,6 +809,7 @@ Transform:
   m_LocalRotation: {x: 0.0000005580623, y: -0.0000024002752, z: -0.26428223, w: 0.9644454}
   m_LocalPosition: {x: -0.3785454, y: 0.0038244387, z: -0.010314554}
   m_LocalScale: {x: 0.9999998, y: 0.9999996, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 234362335}
   m_Father: {fileID: 2107687306}
@@ -823,6 +841,7 @@ Transform:
   m_LocalRotation: {x: -0.0478358, y: -0.0038424567, z: 0.0030543627, w: 0.9988432}
   m_LocalPosition: {x: -0.01920933, y: -0.00029923706, z: -0.00002337768}
   m_LocalScale: {x: 1.0000054, y: 1.0000043, z: 1.0000037}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 262308063}
   m_RootOrder: 0
@@ -853,6 +872,7 @@ Transform:
   m_LocalRotation: {x: 0.11624815, y: 0.69947636, z: -0.10604285, w: 0.6971185}
   m_LocalPosition: {x: -0.12236678, y: -0.0013949821, z: 0.04222679}
   m_LocalScale: {x: 1.0000004, y: 1.0000011, z: 1.0000008}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1989123856}
   m_Father: {fileID: 675793193}
@@ -884,6 +904,7 @@ Transform:
   m_LocalRotation: {x: -0.023811344, y: 0.01439187, z: -0.5187163, w: 0.8544936}
   m_LocalPosition: {x: -0.084295675, y: 0.04771042, z: -0.0039216853}
   m_LocalScale: {x: 1.0000006, y: 0.9999997, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1559605076}
   m_RootOrder: 0
@@ -914,6 +935,7 @@ Transform:
   m_LocalRotation: {x: 0.017483843, y: 0.9998472, z: 5.8411366e-17, w: 1.6185826e-16}
   m_LocalPosition: {x: 0.18568334, y: -0.007424814, z: 0.00000047303573}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2007707494}
   m_Father: {fileID: 613741156}
@@ -945,6 +967,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.1628788, y: -0.0000000020954543, z: 0.0000000016000674}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 468025445}
   m_RootOrder: 0
@@ -975,6 +998,7 @@ Transform:
   m_LocalRotation: {x: -0.10859549, y: -0.021866571, z: -0.0013553738, w: 0.99384457}
   m_LocalPosition: {x: -0.16248195, y: -0.0000006351125, z: 0.00000024924654}
   m_LocalScale: {x: 1.0000014, y: 1.0000011, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 186225966}
   - {fileID: 205337282}
@@ -1010,6 +1034,7 @@ Transform:
   m_LocalRotation: {x: 0.99590546, y: -0.01934041, z: -0.041608024, w: -0.07789138}
   m_LocalPosition: {x: -0.07745903, y: 0.024773534, z: 0.02387737}
   m_LocalScale: {x: 1.0000012, y: 1.0000013, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 203510121}
   m_Father: {fileID: 2006233022}
@@ -1041,6 +1066,7 @@ Transform:
   m_LocalRotation: {x: -0.12178339, y: -0.20300739, z: 0.30530372, w: 0.92235917}
   m_LocalPosition: {x: -0.18103224, y: 0.08604571, z: -0.04305515}
   m_LocalScale: {x: 1.0000005, y: 1.0000007, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1507844007}
   m_Father: {fileID: 791463027}
@@ -1072,6 +1098,7 @@ Transform:
   m_LocalRotation: {x: -0.518709, y: 0.071315005, z: -0.14153358, w: 0.84013295}
   m_LocalPosition: {x: -0.07073235, y: 5.4780847e-17, z: -8.082631e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1246280240}
   m_RootOrder: 0
@@ -1104,6 +1131,7 @@ Transform:
   m_LocalRotation: {x: -0.47192204, y: 0.5467805, z: 0.45703653, w: 0.51907444}
   m_LocalPosition: {x: 1.289459, y: -0.16328037, z: -0.013468142}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1220662872}
   m_RootOrder: 1
@@ -1119,6 +1147,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -1183,6 +1212,7 @@ Transform:
   m_LocalRotation: {x: 0.00013144138, y: 0.013670122, z: 0.032817103, w: 0.9993679}
   m_LocalPosition: {x: -0.14597888, y: 2.1649348e-17, z: 2.7131074e-17}
   m_LocalScale: {x: 1.0000007, y: 1.0000002, z: 1.0000007}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1048370680}
   m_Father: {fileID: 406074854}
@@ -1214,6 +1244,7 @@ Transform:
   m_LocalRotation: {x: 0.055760637, y: 0.11511083, z: 0.06385369, w: 0.98972875}
   m_LocalPosition: {x: -0.08693589, y: -0.00055593316, z: -0.002243447}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1310692782}
   m_RootOrder: 0
@@ -1244,6 +1275,7 @@ Transform:
   m_LocalRotation: {x: 0.008016311, y: -0.09734142, z: 0.058641404, w: 0.9934896}
   m_LocalPosition: {x: -0.13752587, y: -4.6629366e-17, z: -6.106227e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2088554363}
   m_Father: {fileID: 706218996}
@@ -1275,6 +1307,7 @@ Transform:
   m_LocalRotation: {x: 0.002749186, y: -0.061828945, z: 0.0046093785, w: 0.9980723}
   m_LocalPosition: {x: -0.016096681, y: 0.000118210985, z: -0.00045832127}
   m_LocalScale: {x: 1.0000032, y: 1.0000025, z: 1.000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 141137954}
   m_Father: {fileID: 172356952}
@@ -1306,6 +1339,7 @@ Transform:
   m_LocalRotation: {x: 0.858846, y: 0.1550803, z: -0.007265332, w: -0.4881402}
   m_LocalPosition: {x: -0.14172979, y: -4.4408918e-17, z: 2.8865798e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2119275144}
   m_RootOrder: 0
@@ -1337,6 +1371,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 800359998}
   m_RootOrder: 11
@@ -1352,6 +1387,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -1467,6 +1503,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 458647785}
   m_RootOrder: 0
@@ -1540,6 +1577,7 @@ Transform:
   m_LocalRotation: {x: 0.00010815607, y: -0.0073533887, z: -0.05896039, w: 0.99823326}
   m_LocalPosition: {x: 0.0000000018666693, y: -0.000000030172764, z: -2.8229039e-10}
   m_LocalScale: {x: 0.99999946, y: 0.99999946, z: 0.99999964}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 328692593}
   m_Father: {fileID: 1134315401}
@@ -1571,6 +1609,7 @@ Transform:
   m_LocalRotation: {x: -0.014208467, y: -0.0082518505, z: -0.017708749, w: 0.9997082}
   m_LocalPosition: {x: -0.019202955, y: 0.0005186548, z: -0.0002499818}
   m_LocalScale: {x: 1.0000023, y: 1.000002, z: 1.0000015}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 490431110}
   m_RootOrder: 0
@@ -1601,6 +1640,7 @@ Transform:
   m_LocalRotation: {x: -0.7153496, y: -0.024095412, z: 0.023904901, w: 0.6979419}
   m_LocalPosition: {x: -0.021249697, y: 0.0010069837, z: 0.0016369896}
   m_LocalScale: {x: 1.0000044, y: 1.0000023, z: 1.0000025}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 125849476}
   m_RootOrder: 0
@@ -1631,6 +1671,7 @@ Transform:
   m_LocalRotation: {x: 0.004313685, y: -0.020318924, z: 0.019809484, w: 0.999588}
   m_LocalPosition: {x: -0.13656151, y: 1.110223e-16, z: -5.5511148e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1520333808}
   m_Father: {fileID: 1154624516}
@@ -1663,6 +1704,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 800359998}
   m_RootOrder: 2
@@ -1678,6 +1720,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -1759,6 +1802,7 @@ Transform:
   m_LocalRotation: {x: 0.00085945585, y: 0, z: -0, w: 0.99999964}
   m_LocalPosition: {x: -0.10291584, y: 7.566685e-18, z: -7.4712223e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 766305781}
   m_RootOrder: 0
@@ -1789,6 +1833,7 @@ Transform:
   m_LocalRotation: {x: -0.023811344, y: 0.01439187, z: -0.5187163, w: 0.8544936}
   m_LocalPosition: {x: -0.084295675, y: 0.04771042, z: -0.0039216853}
   m_LocalScale: {x: 1.0000006, y: 0.9999997, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1553571409}
   m_RootOrder: 0
@@ -1819,6 +1864,7 @@ Transform:
   m_LocalRotation: {x: 0.00012985706, y: -0.0010473065, z: -0.00044055204, w: 0.99999934}
   m_LocalPosition: {x: -0.23377882, y: 0.00001742176, z: -0.000012771544}
   m_LocalScale: {x: 1, y: 1, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2006233022}
   - {fileID: 1029736165}
@@ -1854,6 +1900,7 @@ Transform:
   m_LocalRotation: {x: -0.0776168, y: 0.08485387, z: 0.12320045, w: 0.98569626}
   m_LocalPosition: {x: -0.076792575, y: -0.012626215, z: -0.0062460983}
   m_LocalScale: {x: 1.0000019, y: 1.0000019, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1918581711}
   m_Father: {fileID: 486394366}
@@ -1885,6 +1932,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.15477863, y: 6.883383e-17, z: 1.2212453e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 335870932}
   m_RootOrder: 0
@@ -1915,6 +1963,7 @@ Transform:
   m_LocalRotation: {x: -0.051588498, y: 0.5376023, z: -0.03311316, w: 0.84096724}
   m_LocalPosition: {x: -0.029250145, y: 0.026847687, z: 0.0006188383}
   m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2079845757}
   m_Father: {fileID: 340343233}
@@ -1946,6 +1995,7 @@ Transform:
   m_LocalRotation: {x: 0.0022775515, y: -0.010616068, z: -0.0041946047, w: 0.9999323}
   m_LocalPosition: {x: -0.02426037, y: 0.0025070603, z: -0.0011865995}
   m_LocalScale: {x: 0.9999998, y: 0.99999976, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 125849476}
   m_Father: {fileID: 968867738}
@@ -1977,6 +2027,7 @@ Transform:
   m_LocalRotation: {x: -0.06448094, y: -0.087481044, z: -0.08295049, w: 0.9906102}
   m_LocalPosition: {x: -0.047045223, y: 0.036010325, z: 0.0010294426}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 662681139}
   m_Father: {fileID: 1171642106}
@@ -2033,13 +2084,14 @@ MonoBehaviour:
   TransitionSetting:
     OutputTargetWeight: 1
     FadeInTime: 0.2
+    FixedTimeOffset: 0
     ExitTime: 0
     ClipSpeed: 1
     RestartWhenPlay: 1
   ToClip: {fileID: 7400000, guid: 26055e26f15260e4e8e0e51f50c41926, type: 3}
 --- !u!95 &175330855
 Animator:
-  serializedVersion: 3
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -2052,10 +2104,12 @@ Animator:
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!4 &175330856
 Transform:
   m_ObjectHideFlags: 0
@@ -2066,6 +2120,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: 3, y: 0, z: 3}
   m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2008790312}
   - {fileID: 935763819}
@@ -2102,6 +2157,7 @@ Transform:
   m_LocalRotation: {x: -0.000032017142, y: -0.00005018094, z: -0.51892006, w: 0.85482275}
   m_LocalPosition: {x: -0.08439235, y: 0.047660332, z: 0.0020256662}
   m_LocalScale: {x: 0.99999994, y: 0.99999946, z: 0.9999996}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1650031966}
   m_RootOrder: 0
@@ -2136,6 +2192,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 3, y: 0.2, z: 3}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1107714120}
   m_RootOrder: 0
@@ -2179,6 +2236,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -2245,6 +2303,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 57266860}
   m_RootOrder: 4
@@ -2377,6 +2436,7 @@ Transform:
   m_LocalRotation: {x: -0.0000025580453, y: 0.0000012854281, z: 0.016447844, w: 0.99986476}
   m_LocalPosition: {x: -0.35179782, y: -0.008010951, z: 0.0051462576}
   m_LocalScale: {x: 0.9999997, y: 0.99999976, z: 0.99999964}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2031983873}
   m_Father: {fileID: 1511192738}
@@ -2408,6 +2468,7 @@ Transform:
   m_LocalRotation: {x: 0.6148564, y: 0.11044633, z: -0.013765099, w: 0.7807456}
   m_LocalPosition: {x: -0.04395507, y: 0.0027187055, z: 0.038988035}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 933404887}
   m_Father: {fileID: 1420697592}
@@ -2439,6 +2500,7 @@ Transform:
   m_LocalRotation: {x: 0.10428145, y: 0.04083601, z: 0.0008412449, w: 0.9937088}
   m_LocalPosition: {x: -0.08074935, y: 0.025713358, z: -0.001428291}
   m_LocalScale: {x: 1.0000013, y: 1.0000015, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 446319708}
   m_Father: {fileID: 99827840}
@@ -2470,6 +2532,7 @@ Transform:
   m_LocalRotation: {x: 0.00085945585, y: 0, z: -0, w: 0.99999964}
   m_LocalPosition: {x: -0.10291584, y: 7.566685e-18, z: -7.4712223e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 806422321}
   m_RootOrder: 0
@@ -2500,6 +2563,7 @@ Transform:
   m_LocalRotation: {x: -0.010046666, y: -0.011496983, z: -0.0012787255, w: 0.99988264}
   m_LocalPosition: {x: -0.013910712, y: 0.0000027587055, z: 0.0002477763}
   m_LocalScale: {x: 1.0000038, y: 1.000003, z: 1.0000027}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1430443032}
   m_Father: {fileID: 1055042377}
@@ -2531,6 +2595,7 @@ Transform:
   m_LocalRotation: {x: -0.3695515, y: 0, z: 0, w: 0.92921025}
   m_LocalPosition: {x: 0, y: 0.54045296, z: -0.8993217}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 175330856}
   m_RootOrder: 5
@@ -2561,6 +2626,7 @@ Transform:
   m_LocalRotation: {x: 0.6148564, y: 0.11044633, z: -0.013765099, w: 0.7807456}
   m_LocalPosition: {x: -0.04395507, y: 0.0027187055, z: 0.038988035}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 624082552}
   m_Father: {fileID: 1030197144}
@@ -2592,6 +2658,7 @@ Transform:
   m_LocalRotation: {x: 0.9905085, y: 0.13556996, z: 0.022448432, w: 0.003137485}
   m_LocalPosition: {x: -0.041387863, y: -0.048911706, z: -0.012787029}
   m_LocalScale: {x: 0.9999999, y: 1.0000006, z: 1.0000008}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2089990011}
   m_Father: {fileID: 2085037210}
@@ -2624,6 +2691,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 644075394}
   m_RootOrder: 0
@@ -2639,6 +2707,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -2713,6 +2782,7 @@ Transform:
   m_LocalRotation: {x: 0.024406396, y: -0.040521923, z: -0.013085931, w: 0.99879485}
   m_LocalPosition: {x: -0.018097645, y: -0.00014428438, z: -0.00005280069}
   m_LocalScale: {x: 1.0000018, y: 1.0000017, z: 1.0000018}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 894592975}
   m_Father: {fileID: 301947287}
@@ -2744,6 +2814,7 @@ Transform:
   m_LocalRotation: {x: -0.028078744, y: 0.033863522, z: -0.00080727146, w: 0.99903166}
   m_LocalPosition: {x: -0.024233012, y: -0.002230036, z: -0.0020085163}
   m_LocalScale: {x: 1, y: 0.99999976, z: 0.9999991}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 582258092}
   m_Father: {fileID: 100610769}
@@ -2775,6 +2846,7 @@ Transform:
   m_LocalRotation: {x: -0.11370098, y: 0.97812754, z: -0.16029842, w: -0.0681406}
   m_LocalPosition: {x: -0.118646674, y: 0.109952554, z: -0.007276585}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1238357391}
   m_Father: {fileID: 1220662872}
@@ -2806,6 +2878,7 @@ Transform:
   m_LocalRotation: {x: 0.057060625, y: -0.015512465, z: 0.05145035, w: 0.99692345}
   m_LocalPosition: {x: -0.08069598, y: 0.0058216397, z: -0.0060212403}
   m_LocalScale: {x: 1.0000017, y: 1.0000018, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 322819920}
   m_Father: {fileID: 99827840}
@@ -2837,6 +2910,7 @@ Transform:
   m_LocalRotation: {x: -0.016843833, y: 0.0388019, z: -0.011487531, w: 0.99903893}
   m_LocalPosition: {x: -0.025354914, y: -0.0006798064, z: 0.0011694904}
   m_LocalScale: {x: 1, y: 0.9999999, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1895185960}
   m_Father: {fileID: 564780876}
@@ -2868,6 +2942,7 @@ Transform:
   m_LocalRotation: {x: 0.10428145, y: 0.04083601, z: 0.0008412449, w: 0.9937088}
   m_LocalPosition: {x: -0.08074935, y: 0.025713358, z: -0.001428291}
   m_LocalScale: {x: 1.0000013, y: 1.0000015, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 819069943}
   m_Father: {fileID: 469796802}
@@ -2899,6 +2974,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.10206888, y: -0.000000016640396, z: -0.000000066199064}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1613615407}
   m_RootOrder: 0
@@ -2929,6 +3005,7 @@ Transform:
   m_LocalRotation: {x: -0.0931137, y: 0.017067054, z: 0.97876835, w: 0.1817996}
   m_LocalPosition: {x: -0.03154395, y: -0.06754832, z: 0.06546028}
   m_LocalScale: {x: 1.000001, y: 1.0000007, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1258178865}
   m_Father: {fileID: 1665962212}
@@ -2960,6 +3037,7 @@ Transform:
   m_LocalRotation: {x: -0.051588498, y: 0.5376023, z: -0.03311316, w: 0.84096724}
   m_LocalPosition: {x: -0.029250145, y: 0.026847687, z: 0.0006188383}
   m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1526159852}
   m_Father: {fileID: 1648083170}
@@ -2991,6 +3069,7 @@ Transform:
   m_LocalRotation: {x: -0.7059503, y: 0.03399268, z: 0.0064747767, w: 0.7074155}
   m_LocalPosition: {x: -0.022013659, y: 0.0009110151, z: 0.00011725739}
   m_LocalScale: {x: 1.0000029, y: 1.0000014, z: 1.0000017}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1301546175}
   m_RootOrder: 0
@@ -3021,6 +3100,7 @@ Transform:
   m_LocalRotation: {x: -0.005350928, y: -0.062506996, z: 0.121605895, w: 0.9905939}
   m_LocalPosition: {x: -0.14993033, y: 5.49367e-17, z: 7.480034e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 604206086}
   m_Father: {fileID: 647968148}
@@ -3054,6 +3134,7 @@ Transform:
   m_LocalRotation: {x: -0.47192204, y: 0.5467805, z: 0.45703653, w: 0.51907444}
   m_LocalPosition: {x: 1.289459, y: -0.16328037, z: -0.013468142}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1220662872}
   m_RootOrder: 5
@@ -3069,6 +3150,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -3133,6 +3215,7 @@ Transform:
   m_LocalRotation: {x: -0.09374654, y: 0.6978552, z: 0.70746905, w: 0.060806755}
   m_LocalPosition: {x: -0.05543403, y: 0.0017306843, z: 0.098653734}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2076469165}
   m_Father: {fileID: 508696215}
@@ -3165,6 +3248,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 326367185}
   - {fileID: 1894353744}
@@ -3269,6 +3353,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.18333384, y: 0.00000003325184, z: 0.00000005255228}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2068976104}
   m_RootOrder: 0
@@ -3299,6 +3384,7 @@ Transform:
   m_LocalRotation: {x: -0.000032017142, y: -0.00005018094, z: -0.51892006, w: 0.85482275}
   m_LocalPosition: {x: -0.08439235, y: 0.047660332, z: 0.0020256662}
   m_LocalScale: {x: 0.99999994, y: 0.99999946, z: 0.9999996}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 67590302}
   m_RootOrder: 0
@@ -3329,6 +3415,7 @@ Transform:
   m_LocalRotation: {x: 0.0221195, y: 0.9987083, z: 0.0010128983, w: 0.045732945}
   m_LocalPosition: {x: -0.068878286, y: 0.07501759, z: 0.056856666}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 766305781}
   - {fileID: 2138379858}
@@ -3361,6 +3448,7 @@ Transform:
   m_LocalRotation: {x: 0.0066097225, y: 0.051325165, z: -0.11946504, w: 0.9914889}
   m_LocalPosition: {x: -0.071971275, y: -0.041271117, z: -0.05366487}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 772533888}
   - {fileID: 1370251187}
@@ -3393,6 +3481,7 @@ Transform:
   m_LocalRotation: {x: 0.000005962055, y: 0.0026267671, z: -0.000676907, w: 0.99999636}
   m_LocalPosition: {x: -0.055436894, y: -0.000000047903697, z: 0.00000091983424}
   m_LocalScale: {x: 0.9999999, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1171642106}
   m_Father: {fileID: 1944284897}
@@ -3424,6 +3513,7 @@ Transform:
   m_LocalRotation: {x: -0.008016839, y: 0.09734642, z: 0.058641255, w: 0.99348915}
   m_LocalPosition: {x: -0.13752584, y: 1.1990408e-16, z: -3.1086245e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1941409541}
   m_Father: {fileID: 1520333808}
@@ -3455,6 +3545,7 @@ Transform:
   m_LocalRotation: {x: 0.1008327, y: 0.026525343, z: 0.9770472, w: 0.18576309}
   m_LocalPosition: {x: -0.033491675, y: -0.07271498, z: -0.058596842}
   m_LocalScale: {x: 1.0000008, y: 1.0000007, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1723316244}
   m_Father: {fileID: 1220662872}
@@ -3486,6 +3577,7 @@ Transform:
   m_LocalRotation: {x: -0.43375266, y: -0.5621338, z: -0.48488638, w: 0.51063645}
   m_LocalPosition: {x: -0.123436436, y: 1.2161711e-16, z: -2.5274234e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1813948891}
   m_RootOrder: 0
@@ -3516,6 +3608,7 @@ Transform:
   m_LocalRotation: {x: -0.3695515, y: 0, z: 0, w: 0.92921025}
   m_LocalPosition: {x: 0, y: 0.54045296, z: -0.8993217}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1912998594}
   m_RootOrder: 5
@@ -3546,6 +3639,7 @@ Transform:
   m_LocalRotation: {x: 0.056542903, y: 0.7048425, z: -0.056542903, w: 0.7048425}
   m_LocalPosition: {x: 0.1630146, y: 0.0000034868867, z: 0.00000009529151}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 973937228}
   m_RootOrder: 0
@@ -3577,6 +3671,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1311595006}
   m_RootOrder: 7
@@ -3592,6 +3687,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -3690,6 +3786,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1821073435}
   m_Father: {fileID: 1424463373}
@@ -3726,6 +3823,7 @@ Transform:
   m_LocalRotation: {x: -0.010046666, y: -0.011496983, z: -0.0012787255, w: 0.99988264}
   m_LocalPosition: {x: -0.013910712, y: 0.0000027587055, z: 0.0002477763}
   m_LocalScale: {x: 1.0000038, y: 1.000003, z: 1.0000027}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 75625657}
   m_Father: {fileID: 1971264170}
@@ -3757,6 +3855,7 @@ Transform:
   m_LocalRotation: {x: 0.012592068, y: -0.04324944, z: -0.00322445, w: 0.99897975}
   m_LocalPosition: {x: -0.025126116, y: -0.00003483637, z: -0.0032739432}
   m_LocalScale: {x: 1.000002, y: 1.0000018, z: 1.0000014}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1440787313}
   m_RootOrder: 0
@@ -3789,6 +3888,7 @@ Transform:
   m_LocalRotation: {x: -0.47192204, y: 0.5467805, z: 0.45703653, w: 0.51907444}
   m_LocalPosition: {x: 1.289459, y: -0.16328037, z: -0.013468142}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2045781770}
   m_RootOrder: 4
@@ -3804,6 +3904,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -3868,6 +3969,7 @@ Transform:
   m_LocalRotation: {x: -0.00000019811638, y: 0.0008595022, z: 0.99999964, w: 0.0000004702604}
   m_LocalPosition: {x: -0.1029153, y: 1.935459e-17, z: 3.6886607e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 312536625}
   m_RootOrder: 0
@@ -3898,6 +4000,7 @@ Transform:
   m_LocalRotation: {x: -0.016843833, y: 0.0388019, z: -0.011487531, w: 0.99903893}
   m_LocalPosition: {x: -0.025354914, y: -0.0006798064, z: 0.0011694904}
   m_LocalScale: {x: 1, y: 0.9999999, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1743498168}
   m_Father: {fileID: 1930364061}
@@ -3929,6 +4032,7 @@ Transform:
   m_LocalRotation: {x: 0.056542926, y: 0.7048425, z: -0.056542926, w: 0.7048425}
   m_LocalPosition: {x: -0.16301435, y: 9.7699626e-17, z: -4.0733682e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1846565071}
   m_RootOrder: 0
@@ -3959,6 +4063,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -3.6212335e-11, y: 0.0374364, z: 0.039560296}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 15058952}
   m_RootOrder: 1
@@ -3990,6 +4095,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 841138544}
   - {fileID: 18655714}
@@ -4093,6 +4199,7 @@ Transform:
   m_LocalRotation: {x: 0.49999982, y: -0.50000024, z: -0.4999999, w: -0.5000001}
   m_LocalPosition: {x: 0, y: -1, z: -0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1066235440}
   m_RootOrder: 1
@@ -4123,6 +4230,7 @@ Transform:
   m_LocalRotation: {x: -0.12178339, y: -0.20300739, z: 0.30530372, w: 0.92235917}
   m_LocalPosition: {x: -0.18103224, y: 0.08604571, z: -0.04305515}
   m_LocalScale: {x: 1.0000005, y: 1.0000007, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2024655052}
   m_Father: {fileID: 1665962212}
@@ -4154,6 +4262,7 @@ Transform:
   m_LocalRotation: {x: -0.02557532, y: -0.010641737, z: 0.026150629, w: 0.99927413}
   m_LocalPosition: {x: -0.026304213, y: -0.0011438475, z: -0.00057086156}
   m_LocalScale: {x: 1.0000046, y: 1.0000029, z: 1.0000036}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1360638655}
   m_RootOrder: 0
@@ -4184,6 +4293,7 @@ Transform:
   m_LocalRotation: {x: -0.0000059582267, y: -0.00262653, z: -0.0006767927, w: 0.99999636}
   m_LocalPosition: {x: -0.055437315, y: -0.000000047463757, z: -0.0000009960296}
   m_LocalScale: {x: 1, y: 0.9999999, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2085037210}
   m_Father: {fileID: 1408965513}
@@ -4215,6 +4325,7 @@ Transform:
   m_LocalRotation: {x: 0.22437504, y: 0.670564, z: -0.50672334, w: -0.4931849}
   m_LocalPosition: {x: -0.14172885, y: -9.7699626e-17, z: -6.7279734e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2024655052}
   m_RootOrder: 0
@@ -4245,6 +4356,7 @@ Transform:
   m_LocalRotation: {x: -0.3895228, y: 0.5901459, z: -0.51284444, w: -0.48681676}
   m_LocalPosition: {x: -0.07073497, y: 3.330669e-17, z: -1.1213252e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 920338942}
   m_RootOrder: 0
@@ -4275,6 +4387,7 @@ Transform:
   m_LocalRotation: {x: 0.95549077, y: 0.1616498, z: 0.04944903, w: -0.24178815}
   m_LocalPosition: {x: -0.065019004, y: -0.027721604, z: 0.010366318}
   m_LocalScale: {x: 1.0000012, y: 1.0000013, z: 1.000001}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 200516198}
   m_Father: {fileID: 617037369}
@@ -4306,6 +4419,7 @@ Transform:
   m_LocalRotation: {x: 0.84096724, y: 0.03311328, z: 0.5376023, w: 0.05158868}
   m_LocalPosition: {x: 0.029250061, y: 0.02684879, z: 0.0006188783}
   m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 973937228}
   m_Father: {fileID: 15058952}
@@ -4339,6 +4453,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 468928396}
   m_RootOrder: 0
@@ -4412,6 +4527,7 @@ Transform:
   m_LocalRotation: {x: 0.005350928, y: -0.061189618, z: 0.12227407, w: 0.9905939}
   m_LocalPosition: {x: 0.14993037, y: -0.000000002250124, z: -0.000000010045328}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1984981746}
   m_Father: {fileID: 1217311753}
@@ -4444,6 +4560,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1833912637}
   m_RootOrder: 13
@@ -4459,6 +4576,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -4571,6 +4689,7 @@ Transform:
   m_LocalRotation: {x: -0.002221635, y: -0.033948217, z: 0.021046568, w: 0.9991995}
   m_LocalPosition: {x: -0.14191027, y: 3.7508402e-17, z: 3.2530684e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 275866558}
   m_Father: {fileID: 1109097618}
@@ -4602,6 +4721,7 @@ Transform:
   m_LocalRotation: {x: -0.10604028, y: -0.697103, z: -0.11625049, w: 0.69949174}
   m_LocalPosition: {x: -0.122454844, y: -0.00014976753, z: -0.041993644}
   m_LocalScale: {x: 1.0000011, y: 1.000001, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 678676036}
   m_Father: {fileID: 373212390}
@@ -4635,6 +4755,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1575068690}
   m_RootOrder: 0
@@ -4708,6 +4829,7 @@ Transform:
   m_LocalRotation: {x: -0.06448094, y: -0.087481044, z: -0.08295049, w: 0.9906102}
   m_LocalPosition: {x: -0.047045223, y: 0.036010325, z: 0.0010294426}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 647000835}
   m_Father: {fileID: 1420697592}
@@ -4739,6 +4861,7 @@ Transform:
   m_LocalRotation: {x: 0.11624815, y: 0.69947636, z: -0.10604285, w: 0.6971185}
   m_LocalPosition: {x: -0.12236678, y: -0.0013949821, z: 0.04222679}
   m_LocalScale: {x: 1.0000004, y: 1.0000011, z: 1.0000008}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 955220498}
   m_Father: {fileID: 1009839551}
@@ -4770,6 +4893,7 @@ Transform:
   m_LocalRotation: {x: -0.03357769, y: 0.06963723, z: -0.014093166, w: 0.99690753}
   m_LocalPosition: {x: -0.025063124, y: 0.0014819854, z: 0.00379354}
   m_LocalScale: {x: 1, y: 0.99999994, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 556145870}
   m_Father: {fileID: 205337282}
@@ -4803,6 +4927,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1403471705}
   m_RootOrder: 4
@@ -4937,6 +5062,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2023630874}
   m_RootOrder: 3
@@ -5071,6 +5197,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 231704635}
   m_RootOrder: 0
@@ -5144,6 +5271,7 @@ Transform:
   m_LocalRotation: {x: -0.5071907, y: -0.49270436, z: -0.454019, w: 0.5420949}
   m_LocalPosition: {x: -0.12343654, y: 2.4047247e-17, z: -4.297936e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 140022228}
   m_RootOrder: 0
@@ -5174,6 +5302,7 @@ Transform:
   m_LocalRotation: {x: -0.00013146584, y: -0.013670889, z: 0.032817043, w: 0.9993679}
   m_LocalPosition: {x: -0.1459784, y: -4.6629366e-17, z: -2.4528989e-17}
   m_LocalScale: {x: 1.0000007, y: 1.0000002, z: 1.0000007}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 169255534}
   m_Father: {fileID: 2063211963}
@@ -5205,6 +5334,7 @@ Transform:
   m_LocalRotation: {x: 0.017483843, y: 0.9998472, z: 5.8411366e-17, w: 1.6185826e-16}
   m_LocalPosition: {x: 0.18568334, y: -0.007424814, z: 0.00000047303573}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1482038855}
   m_Father: {fileID: 341465787}
@@ -5236,6 +5366,7 @@ Transform:
   m_LocalRotation: {x: -0.000032017142, y: -0.00005018094, z: -0.51892006, w: 0.85482275}
   m_LocalPosition: {x: -0.08439235, y: 0.047660332, z: 0.0020256662}
   m_LocalScale: {x: 0.99999994, y: 0.99999946, z: 0.9999996}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 991104488}
   m_RootOrder: 0
@@ -5291,13 +5422,14 @@ MonoBehaviour:
   TransitionSetting:
     OutputTargetWeight: 1
     FadeInTime: 0.2
+    FixedTimeOffset: 0
     ExitTime: 0
     ClipSpeed: 1
     RestartWhenPlay: 1
   ToClip: {fileID: 7400000, guid: 26055e26f15260e4e8e0e51f50c41926, type: 3}
 --- !u!95 &337441686
 Animator:
-  serializedVersion: 3
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -5310,10 +5442,12 @@ Animator:
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!4 &337441687
 Transform:
   m_ObjectHideFlags: 0
@@ -5324,6 +5458,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: 3, y: 0, z: 3}
   m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 51980835}
   - {fileID: 1229912148}
@@ -5360,6 +5495,7 @@ Transform:
   m_LocalRotation: {x: -0.4967837, y: 0.50319576, z: 0.4967837, w: 0.50319576}
   m_LocalPosition: {x: -0.08766683, y: -0.0003044751, z: 0.00000001784587}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 171290356}
   - {fileID: 413570748}
@@ -5393,6 +5529,7 @@ Transform:
   m_LocalRotation: {x: 0.84096724, y: 0.03311328, z: 0.5376023, w: 0.05158868}
   m_LocalPosition: {x: 0.029250061, y: 0.02684879, z: 0.0006188783}
   m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 336923209}
   m_Father: {fileID: 340343233}
@@ -5424,6 +5561,7 @@ Transform:
   m_LocalRotation: {x: 0.0033062587, y: 0.044774964, z: -0.021614037, w: 0.9987578}
   m_LocalPosition: {x: 1.3805066e-32, y: 3.5527136e-17, z: 3.315681e-32}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 807093039}
   m_Father: {fileID: 647968148}
@@ -5455,6 +5593,7 @@ Transform:
   m_LocalRotation: {x: 0.00013144138, y: 0.013670122, z: 0.032817103, w: 0.9993679}
   m_LocalPosition: {x: -0.14597888, y: 2.1649348e-17, z: 2.7131074e-17}
   m_LocalScale: {x: 1.0000007, y: 1.0000002, z: 1.0000007}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 831376342}
   m_Father: {fileID: 1891178740}
@@ -5486,6 +5625,7 @@ Transform:
   m_LocalRotation: {x: 0.9905085, y: 0.13556996, z: 0.022448432, w: 0.003137485}
   m_LocalPosition: {x: -0.041387863, y: -0.048911706, z: -0.012787029}
   m_LocalScale: {x: 0.9999999, y: 1.0000006, z: 1.0000008}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1102917248}
   m_Father: {fileID: 1649063563}
@@ -5517,6 +5657,7 @@ Transform:
   m_LocalRotation: {x: 0.00085945585, y: 0, z: -0, w: 0.99999964}
   m_LocalPosition: {x: -0.10291584, y: 7.566685e-18, z: -7.4712223e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 23038245}
   m_RootOrder: 0
@@ -5547,6 +5688,7 @@ Transform:
   m_LocalRotation: {x: -0.0072285878, y: -0.0016318581, z: 0.15084802, w: 0.9885292}
   m_LocalPosition: {x: -0.08766678, y: -0.00030446955, z: -0.000000018569484}
   m_LocalScale: {x: 1.0000002, y: 1.0000004, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1944284897}
   - {fileID: 1302843395}
@@ -5580,6 +5722,7 @@ Transform:
   m_LocalRotation: {x: 0.012592068, y: -0.04324944, z: -0.00322445, w: 0.99897975}
   m_LocalPosition: {x: -0.025126116, y: -0.00003483637, z: -0.0032739432}
   m_LocalScale: {x: 1.000002, y: 1.0000018, z: 1.0000014}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1271161871}
   m_RootOrder: 0
@@ -5610,6 +5753,7 @@ Transform:
   m_LocalRotation: {x: 0.00012215874, y: -0.00051764084, z: 0.0027444, w: 0.9999961}
   m_LocalPosition: {x: -0.11597514, y: 6.217249e-17, z: -2.5535128e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1075824745}
   m_Father: {fileID: 1456232291}
@@ -5641,6 +5785,7 @@ Transform:
   m_LocalRotation: {x: 0.0066097225, y: 0.051325165, z: -0.11946504, w: 0.9914889}
   m_LocalPosition: {x: -0.071971275, y: -0.041271117, z: -0.05366487}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1355941513}
   - {fileID: 412768721}
@@ -5673,6 +5818,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 810221240}
   m_Father: {fileID: 1066235440}
@@ -5704,6 +5850,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.09931313, y: -0.009805115, z: -0.0015692547}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 612478040}
   m_RootOrder: 0
@@ -5734,6 +5881,7 @@ Transform:
   m_LocalRotation: {x: -0.009559559, y: 0.011778613, z: -0.014041897, w: 0.9997863}
   m_LocalPosition: {x: -0.017586209, y: 0.0005113313, z: 0.000152205}
   m_LocalScale: {x: 1.0000015, y: 1.0000012, z: 1.0000017}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 619550925}
   m_Father: {fileID: 931783302}
@@ -5765,6 +5913,7 @@ Transform:
   m_LocalRotation: {x: -0.0000073946076, y: -0.0000015158422, z: 0.016451556, w: 0.9998647}
   m_LocalPosition: {x: -0.35136372, y: -0.0080112815, z: -0.018233713}
   m_LocalScale: {x: 1.0000002, y: 1.0000002, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 401353169}
   m_Father: {fileID: 1531712338}
@@ -5798,6 +5947,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 231704635}
   m_RootOrder: 4
@@ -5930,6 +6080,7 @@ Transform:
   m_LocalRotation: {x: 0.03296851, y: 0.011079731, z: 0.00012965832, w: 0.999395}
   m_LocalPosition: {x: -0.032029476, y: 0.0011279538, z: 0.0006024109}
   m_LocalScale: {x: 0.9999999, y: 0.99999976, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 758367463}
   m_Father: {fileID: 1507137045}
@@ -5961,6 +6112,7 @@ Transform:
   m_LocalRotation: {x: 0.0000005580623, y: -0.0000024002752, z: -0.26428223, w: 0.9644454}
   m_LocalPosition: {x: -0.3785454, y: 0.0038244387, z: -0.010314554}
   m_LocalScale: {x: 0.9999998, y: 0.9999996, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1167280445}
   m_Father: {fileID: 393258976}
@@ -5992,6 +6144,7 @@ Transform:
   m_LocalRotation: {x: -0.000108155284, y: 0.0073531894, z: -0.058960136, w: 0.99823326}
   m_LocalPosition: {x: -1.4210854e-16, y: -3.5527136e-17, z: -1.7763568e-17}
   m_LocalScale: {x: 0.99999946, y: 0.99999946, z: 0.99999964}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 686883888}
   m_Father: {fileID: 1368825472}
@@ -6023,6 +6176,7 @@ Transform:
   m_LocalRotation: {x: -0.008016839, y: 0.09734642, z: 0.058641255, w: 0.99348915}
   m_LocalPosition: {x: -0.13752584, y: 1.1990408e-16, z: -3.1086245e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 117320079}
   m_Father: {fileID: 1816965476}
@@ -6054,6 +6208,7 @@ Transform:
   m_LocalRotation: {x: 0.06180407, y: -0.113891736, z: -0.0007837494, w: 0.9915686}
   m_LocalPosition: {x: -0.021074723, y: -0.00070411974, z: -0.0032540236}
   m_LocalScale: {x: 1.0000017, y: 1.0000018, z: 1.0000014}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1203157335}
   m_RootOrder: 0
@@ -6084,6 +6239,7 @@ Transform:
   m_LocalRotation: {x: 0.003306259, y: 0.044774983, z: -0.02161404, w: 0.9987578}
   m_LocalPosition: {x: -0, y: -7.105427e-17, z: 1.7763568e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 901947371}
   m_Father: {fileID: 379840832}
@@ -6115,6 +6271,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -3.6212335e-11, y: 0.0374364, z: 0.039560296}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 340343233}
   m_RootOrder: 1
@@ -6145,6 +6302,7 @@ Transform:
   m_LocalRotation: {x: 0.5562991, y: 0.41471618, z: 0.11796325, w: 0.71037066}
   m_LocalPosition: {x: -0.08505328, y: -1.6764368e-16, z: 1.1990408e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 427014362}
   m_Father: {fileID: 933258910}
@@ -6176,6 +6334,7 @@ Transform:
   m_LocalRotation: {x: -0.0776168, y: 0.08485387, z: 0.12320045, w: 0.98569626}
   m_LocalPosition: {x: -0.076792575, y: -0.012626215, z: -0.0062460983}
   m_LocalScale: {x: 1.0000019, y: 1.0000019, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2059566617}
   m_Father: {fileID: 1410784690}
@@ -6207,6 +6366,7 @@ Transform:
   m_LocalRotation: {x: -0.000000008911413, y: 0.99850297, z: -0.05469786, w: -0.00000016267678}
   m_LocalPosition: {x: 0.1, y: 1.3677425, z: 2.6517928}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1066235440}
   m_RootOrder: 4
@@ -6237,6 +6397,7 @@ Transform:
   m_LocalRotation: {x: 0.858846, y: 0.1550803, z: -0.007265332, w: -0.4881402}
   m_LocalPosition: {x: -0.14172979, y: -4.4408918e-17, z: 2.8865798e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1203742626}
   m_RootOrder: 0
@@ -6267,6 +6428,7 @@ Transform:
   m_LocalRotation: {x: -0.02156939, y: -0.07812919, z: -0.015850486, w: 0.9965839}
   m_LocalPosition: {x: -0.023458017, y: -0.000007917646, z: -0.0035078856}
   m_LocalScale: {x: 0.9999999, y: 0.9999998, z: 0.99999976}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1271161871}
   m_Father: {fileID: 1109227094}
@@ -6298,6 +6460,7 @@ Transform:
   m_LocalRotation: {x: 0.011196001, y: 0.99993575, z: 0.000012512218, w: 0.0017732558}
   m_LocalPosition: {x: 0.06083579, y: 0.0020787853, z: -0.072552614}
   m_LocalScale: {x: 1, y: 1.0000002, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2107687306}
   m_Father: {fileID: 810221240}
@@ -6329,6 +6492,7 @@ Transform:
   m_LocalRotation: {x: 0.858846, y: 0.1550803, z: -0.007265332, w: -0.4881402}
   m_LocalPosition: {x: -0.14172979, y: -4.4408918e-17, z: 2.8865798e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 413746500}
   m_RootOrder: 0
@@ -6359,6 +6523,7 @@ Transform:
   m_LocalRotation: {x: -0.11370098, y: 0.97812754, z: -0.16029842, w: -0.0681406}
   m_LocalPosition: {x: -0.118646674, y: 0.109952554, z: -0.007276585}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1680747393}
   m_Father: {fileID: 1665962212}
@@ -6390,6 +6555,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.09931355, y: 0.009804863, z: 0.0015692349}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 792936147}
   m_RootOrder: 0
@@ -6420,6 +6586,7 @@ Transform:
   m_LocalRotation: {x: -0.023811344, y: 0.01439187, z: -0.5187163, w: 0.8544936}
   m_LocalPosition: {x: -0.084295675, y: 0.04771042, z: -0.0039216853}
   m_LocalScale: {x: 1.0000006, y: 0.9999997, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1653001471}
   m_RootOrder: 0
@@ -6450,6 +6617,7 @@ Transform:
   m_LocalRotation: {x: 0.0033316321, y: -0.0169537, z: -0.0026204463, w: 0.9998473}
   m_LocalPosition: {x: -0.025226552, y: -0.00011562025, z: -0.0023841697}
   m_LocalScale: {x: 1.0000039, y: 1.0000029, z: 1.0000024}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5273866}
   m_RootOrder: 0
@@ -6480,6 +6648,7 @@ Transform:
   m_LocalRotation: {x: 0.0022775515, y: -0.010616068, z: -0.0041946047, w: 0.9999323}
   m_LocalPosition: {x: -0.02426037, y: 0.0025070603, z: -0.0011865995}
   m_LocalScale: {x: 0.9999998, y: 0.99999976, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 920407375}
   m_Father: {fileID: 186225966}
@@ -6512,6 +6681,7 @@ Transform:
   m_LocalRotation: {x: -0.47192225, y: 0.5467804, z: 0.45703635, w: 0.51907456}
   m_LocalPosition: {x: 1.2894577, y: -0.16327994, z: -0.01346737}
   m_LocalScale: {x: 1.0000006, y: 1.0000008, z: 1.000001}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 791463027}
   m_RootOrder: 14
@@ -6527,6 +6697,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -6605,6 +6776,7 @@ Transform:
   m_LocalRotation: {x: 0.15654893, y: 0.97501314, z: -0.017381625, w: 0.15665177}
   m_LocalPosition: {x: -0.09528863, y: 0.084203795, z: 0.08411823}
   m_LocalScale: {x: 1.0000006, y: 1.0000005, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1998879210}
   m_Father: {fileID: 2045781770}
@@ -6637,6 +6809,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 800359998}
   m_RootOrder: 4
@@ -6652,6 +6825,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -6739,6 +6913,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 774205173}
   m_RootOrder: 6
@@ -6754,6 +6929,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -6874,6 +7050,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1086404222}
   m_Father: {fileID: 1399643595}
@@ -7016,6 +7193,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 133132533}
   m_Father: {fileID: 1403471705}
@@ -7052,6 +7230,7 @@ Transform:
   m_LocalRotation: {x: -0.06448094, y: -0.087481044, z: -0.08295049, w: 0.9906102}
   m_LocalPosition: {x: -0.047045223, y: 0.036010325, z: 0.0010294426}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 650521269}
   m_Father: {fileID: 1030197144}
@@ -7083,6 +7262,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.18333384, y: 0.00000003325184, z: 0.00000005255228}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1355941513}
   m_RootOrder: 0
@@ -7114,6 +7294,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 800359998}
   m_RootOrder: 12
@@ -7129,6 +7310,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -7212,6 +7394,7 @@ Transform:
   m_LocalRotation: {x: 0.024406396, y: -0.040521923, z: -0.013085931, w: 0.99879485}
   m_LocalPosition: {x: -0.018097645, y: -0.00014428438, z: -0.00005280069}
   m_LocalScale: {x: 1.0000018, y: 1.0000017, z: 1.0000018}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 836970271}
   m_Father: {fileID: 1740126887}
@@ -7243,6 +7426,7 @@ Transform:
   m_LocalRotation: {x: 0.011179984, y: 0.99979585, z: 0.00023534863, w: -0.016828509}
   m_LocalPosition: {x: 0.06031916, y: 0.0020788328, z: 0.07298301}
   m_LocalScale: {x: 1.0000004, y: 1.0000005, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 517371545}
   m_Father: {fileID: 810221240}
@@ -7275,6 +7459,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1311595006}
   m_RootOrder: 10
@@ -7290,6 +7475,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -7465,6 +7651,7 @@ Transform:
   m_LocalRotation: {x: 0.99050975, y: 0.13555767, z: -0.022467816, w: -0.0031346574}
   m_LocalPosition: {x: -0.041389998, y: -0.048910234, z: 0.012788884}
   m_LocalScale: {x: 1.0000011, y: 1.0000005, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 99192625}
   m_Father: {fileID: 1030197144}
@@ -7496,6 +7683,7 @@ Transform:
   m_LocalRotation: {x: 0.00007596266, y: -0.0017745967, z: -0.04276636, w: 0.9990835}
   m_LocalPosition: {x: -0.022713343, y: 0.008181497, z: -0.00008069934}
   m_LocalScale: {x: 1.0000002, y: 1.0000004, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 912790566}
   - {fileID: 1155104052}
@@ -7529,6 +7717,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 306908149}
   m_Father: {fileID: 1403471705}
@@ -7565,6 +7754,7 @@ Transform:
   m_LocalRotation: {x: 0.057060625, y: -0.015512465, z: 0.05145035, w: 0.99692345}
   m_LocalPosition: {x: -0.08069598, y: 0.0058216397, z: -0.0060212403}
   m_LocalScale: {x: 1.0000017, y: 1.0000018, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2128587110}
   m_Father: {fileID: 1410784690}
@@ -7597,6 +7787,7 @@ Transform:
   m_LocalRotation: {x: -0.47192225, y: 0.5467804, z: 0.45703635, w: 0.51907456}
   m_LocalPosition: {x: 1.2894577, y: -0.16327994, z: -0.01346737}
   m_LocalScale: {x: 1.0000006, y: 1.0000008, z: 1.000001}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1665962212}
   m_RootOrder: 0
@@ -7612,6 +7803,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -7685,6 +7877,7 @@ Transform:
   m_LocalRotation: {x: -0.10859549, y: -0.021866571, z: -0.0013553738, w: 0.99384457}
   m_LocalPosition: {x: -0.16248195, y: -0.0000006351125, z: 0.00000024924654}
   m_LocalScale: {x: 1.0000014, y: 1.0000011, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 216615211}
   - {fileID: 800839278}
@@ -7720,6 +7913,7 @@ Transform:
   m_LocalRotation: {x: 0.055760637, y: 0.11511083, z: 0.06385369, w: 0.98972875}
   m_LocalPosition: {x: -0.08693589, y: -0.00055593316, z: -0.002243447}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1729972868}
   m_RootOrder: 0
@@ -7750,6 +7944,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1063803433}
   m_Father: {fileID: 2023630874}
@@ -7786,6 +7981,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.14900754, y: -0.013332438, z: 0.007244749}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 702050730}
   m_RootOrder: 0
@@ -7816,6 +8012,7 @@ Transform:
   m_LocalRotation: {x: -0.054846227, y: 0.006185361, z: 0.99130034, w: 0.11948777}
   m_LocalPosition: {x: -0.072350614, y: -0.041271094, z: 0.05315229}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 631263512}
   - {fileID: 2021823621}
@@ -7848,6 +8045,7 @@ Transform:
   m_LocalRotation: {x: -0.10859549, y: -0.021866571, z: -0.0013553738, w: 0.99384457}
   m_LocalPosition: {x: -0.16248195, y: -0.0000006351125, z: 0.00000024924654}
   m_LocalScale: {x: 1.0000014, y: 1.0000011, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 968867738}
   - {fileID: 2103971482}
@@ -7883,6 +8081,7 @@ Transform:
   m_LocalRotation: {x: 0.017632259, y: 0.014270657, z: -0.00057296036, w: 0.99974257}
   m_LocalPosition: {x: -0.013885546, y: 0.0002669609, z: 0.00082812016}
   m_LocalScale: {x: 1.000002, y: 1.0000019, z: 1.0000018}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 140153342}
   m_Father: {fileID: 1824010197}
@@ -7916,6 +8115,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1083473877}
   m_RootOrder: 0
@@ -7993,6 +8193,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 3, y: 0.2, z: 3}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2067176395}
   m_RootOrder: 0
@@ -8036,6 +8237,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -8101,6 +8303,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 800359998}
   m_RootOrder: 9
@@ -8116,6 +8319,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -8206,6 +8410,7 @@ Transform:
   m_LocalRotation: {x: 0.00007596266, y: -0.0017745967, z: -0.04276636, w: 0.9990835}
   m_LocalPosition: {x: -0.022713343, y: 0.008181497, z: -0.00008069934}
   m_LocalScale: {x: 1.0000002, y: 1.0000004, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 608119739}
   - {fileID: 792936147}
@@ -8239,6 +8444,7 @@ Transform:
   m_LocalRotation: {x: 0.9641222, y: 0.08804348, z: 0.08698386, w: -0.23484161}
   m_LocalPosition: {x: -0.07430402, y: -0.013710743, z: 0.01965605}
   m_LocalScale: {x: 1.0000013, y: 1.0000014, z: 1.0000008}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 602846087}
   m_Father: {fileID: 1611882741}
@@ -8270,6 +8476,7 @@ Transform:
   m_LocalRotation: {x: 0.00007596266, y: -0.0017745967, z: -0.04276636, w: 0.9990835}
   m_LocalPosition: {x: -0.022713343, y: 0.008181497, z: -0.00008069934}
   m_LocalScale: {x: 1.0000002, y: 1.0000004, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2028780610}
   - {fileID: 231517898}
@@ -8303,6 +8510,7 @@ Transform:
   m_LocalRotation: {x: -0.005350928, y: -0.062506996, z: 0.121605895, w: 0.9905939}
   m_LocalPosition: {x: -0.14993033, y: 5.49367e-17, z: 7.480034e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 569318352}
   m_Father: {fileID: 1886154246}
@@ -8335,6 +8543,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1311595006}
   m_RootOrder: 8
@@ -8350,6 +8559,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -8475,6 +8685,7 @@ Transform:
   m_LocalRotation: {x: -0.47192225, y: 0.5467804, z: 0.45703635, w: 0.51907456}
   m_LocalPosition: {x: 1.2894577, y: -0.16327994, z: -0.01346737}
   m_LocalScale: {x: 1.0000006, y: 1.0000008, z: 1.000001}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2045781770}
   m_RootOrder: 14
@@ -8490,6 +8701,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -8568,6 +8780,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.1628788, y: -0.0000000020954543, z: 0.0000000016000674}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1984665812}
   m_RootOrder: 0
@@ -8598,6 +8811,7 @@ Transform:
   m_LocalRotation: {x: -0.0000025580453, y: 0.0000012854281, z: 0.016447844, w: 0.99986476}
   m_LocalPosition: {x: -0.35179782, y: -0.008010951, z: 0.0051462576}
   m_LocalScale: {x: 0.9999997, y: 0.99999976, z: 0.99999964}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1553571409}
   m_Father: {fileID: 465768723}
@@ -8629,6 +8843,7 @@ Transform:
   m_LocalRotation: {x: -0.022844326, y: -0.05376183, z: 0.017722234, w: 0.99813515}
   m_LocalPosition: {x: -0.01943113, y: -0.00006783814, z: 0.00016170353}
   m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1539405400}
   m_Father: {fileID: 1148831859}
@@ -8660,6 +8875,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.10206909, y: -2.450161e-18, z: -3.9570888e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1633130421}
   m_RootOrder: 0
@@ -8691,6 +8907,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 800359998}
   m_RootOrder: 14
@@ -8706,6 +8923,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -8820,6 +9038,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 18655714}
   m_RootOrder: 0
@@ -8893,6 +9112,7 @@ Transform:
   m_LocalRotation: {x: -0.02557532, y: -0.010641737, z: 0.026150629, w: 0.99927413}
   m_LocalPosition: {x: -0.026304213, y: -0.0011438475, z: -0.00057086156}
   m_LocalScale: {x: 1.0000046, y: 1.0000029, z: 1.0000036}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2014733666}
   m_RootOrder: 0
@@ -8925,6 +9145,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1144138181}
   m_RootOrder: 0
@@ -8998,6 +9219,7 @@ Transform:
   m_LocalRotation: {x: -0.10604028, y: -0.697103, z: -0.11625049, w: 0.69949174}
   m_LocalPosition: {x: -0.122454844, y: -0.00014976753, z: -0.041993644}
   m_LocalScale: {x: 1.0000011, y: 1.000001, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1367256058}
   m_Father: {fileID: 675793193}
@@ -9029,6 +9251,7 @@ Transform:
   m_LocalRotation: {x: 0.017632259, y: 0.014270657, z: -0.00057296036, w: 0.99974257}
   m_LocalPosition: {x: -0.013885546, y: 0.0002669609, z: 0.00082812016}
   m_LocalScale: {x: 1.000002, y: 1.0000019, z: 1.0000018}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1198294825}
   m_Father: {fileID: 1025002729}
@@ -9062,6 +9285,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 4, y: 4, z: 4}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1935541667}
   m_RootOrder: 0
@@ -9141,6 +9365,7 @@ Transform:
   m_LocalRotation: {x: -0.47192204, y: 0.5467805, z: 0.45703653, w: 0.51907444}
   m_LocalPosition: {x: 1.289459, y: -0.16328037, z: -0.013468142}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 791463027}
   m_RootOrder: 3
@@ -9156,6 +9381,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -9220,6 +9446,7 @@ Transform:
   m_LocalRotation: {x: -0.0056373896, y: 0.03380287, z: 0.024109717, w: 0.9991218}
   m_LocalPosition: {x: -0.13228849, y: -1.1324275e-16, z: -1.1268764e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 687619508}
   m_Father: {fileID: 1075824745}
@@ -9251,6 +9478,7 @@ Transform:
   m_LocalRotation: {x: -0.03357769, y: 0.06963723, z: -0.014093166, w: 0.99690753}
   m_LocalPosition: {x: -0.025063124, y: 0.0014819854, z: 0.00379354}
   m_LocalScale: {x: 1, y: 0.99999994, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1301546175}
   m_Father: {fileID: 2103971482}
@@ -9282,6 +9510,7 @@ Transform:
   m_LocalRotation: {x: -0.022844326, y: -0.05376183, z: 0.017722234, w: 0.99813515}
   m_LocalPosition: {x: -0.01943113, y: -0.00006783814, z: 0.00016170353}
   m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1148578542}
   m_Father: {fileID: 322819920}
@@ -9313,6 +9542,7 @@ Transform:
   m_LocalRotation: {x: 0.055760637, y: 0.11511083, z: 0.06385369, w: 0.98972875}
   m_LocalPosition: {x: -0.08693589, y: -0.00055593316, z: -0.002243447}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 712791947}
   m_RootOrder: 0
@@ -9343,6 +9573,7 @@ Transform:
   m_LocalRotation: {x: 0.50088733, y: -0.4991111, z: -0.4991111, w: 0.50088733}
   m_LocalPosition: {x: -0, y: 0.86858183, z: 0.011826879}
   m_LocalScale: {x: 0.9999992, y: 0.9999991, z: 0.9999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 577214716}
   - {fileID: 611929951}
@@ -9382,6 +9613,7 @@ Transform:
   m_LocalRotation: {x: -0.47192204, y: 0.5467805, z: 0.45703653, w: 0.51907444}
   m_LocalPosition: {x: 1.289459, y: -0.16328037, z: -0.013468142}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2045781770}
   m_RootOrder: 5
@@ -9397,6 +9629,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -9461,6 +9694,7 @@ Transform:
   m_LocalRotation: {x: 0.9944477, y: 0.028325185, z: -0.06578186, w: -0.077098854}
   m_LocalPosition: {x: -0.07734096, y: 0.004360036, z: 0.024110846}
   m_LocalScale: {x: 1.0000012, y: 1.0000014, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 210577459}
   m_Father: {fileID: 2006233022}
@@ -9492,6 +9726,7 @@ Transform:
   m_LocalRotation: {x: -0.0000025580453, y: 0.0000012854281, z: 0.016447844, w: 0.99986476}
   m_LocalPosition: {x: -0.35179782, y: -0.008010951, z: 0.0051462576}
   m_LocalScale: {x: 0.9999997, y: 0.99999976, z: 0.99999964}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1559605076}
   m_Father: {fileID: 577214716}
@@ -9523,6 +9758,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.18333411, y: 4.013332e-17, z: -2.5364335e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 511649317}
   m_RootOrder: 0
@@ -9553,6 +9789,7 @@ Transform:
   m_LocalRotation: {x: -0.00000019811638, y: 0.0008595022, z: 0.99999964, w: 0.0000004702604}
   m_LocalPosition: {x: -0.1029153, y: 1.935459e-17, z: 3.6886607e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 25958704}
   m_RootOrder: 0
@@ -9584,6 +9821,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 774205173}
   m_RootOrder: 7
@@ -9599,6 +9837,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -9697,6 +9936,7 @@ Transform:
   m_LocalRotation: {x: 0.0033062587, y: 0.044774964, z: -0.021614037, w: 0.9987578}
   m_LocalPosition: {x: 1.3805066e-32, y: 3.5527136e-17, z: 3.315681e-32}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1280055431}
   m_Father: {fileID: 806950728}
@@ -9728,6 +9968,7 @@ Transform:
   m_LocalRotation: {x: 0.011179984, y: 0.99979585, z: 0.00023534863, w: -0.016828509}
   m_LocalPosition: {x: 0.06031916, y: 0.0020788328, z: 0.07298301}
   m_LocalScale: {x: 1.0000004, y: 1.0000005, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 568071228}
   m_Father: {fileID: 563286634}
@@ -9760,6 +10001,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1833912637}
   m_RootOrder: 8
@@ -9775,6 +10017,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -9899,6 +10142,7 @@ Transform:
   m_LocalRotation: {x: -0.038566142, y: -0.0144198695, z: -0.0068944027, w: 0.9991282}
   m_LocalPosition: {x: -0.015886165, y: 0.0000011769014, z: -0.0026419829}
   m_LocalScale: {x: 1.0000015, y: 1.0000019, z: 1.0000019}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1407863991}
   m_Father: {fileID: 203510121}
@@ -9930,6 +10174,7 @@ Transform:
   m_LocalRotation: {x: -0.70609546, y: -0.036204185, z: -0.035443116, w: 0.7063018}
   m_LocalPosition: {x: -0.044251043, y: 0.00025278676, z: -0.037730616}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 623161349}
   m_Father: {fileID: 1030197144}
@@ -9963,6 +10208,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1403471705}
   m_RootOrder: 3
@@ -10096,6 +10342,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1311595006}
   m_RootOrder: 9
@@ -10111,6 +10358,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -10201,6 +10449,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.15477863, y: 6.883383e-17, z: 1.2212453e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1103808384}
   m_RootOrder: 0
@@ -10231,6 +10480,7 @@ Transform:
   m_LocalRotation: {x: -0.002221635, y: -0.033948217, z: 0.021046568, w: 0.9991995}
   m_LocalPosition: {x: -0.14191027, y: 3.7508402e-17, z: 3.2530684e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2069131155}
   m_Father: {fileID: 1092965446}
@@ -10262,6 +10512,7 @@ Transform:
   m_LocalRotation: {x: -0.02156939, y: -0.07812919, z: -0.015850486, w: 0.9965839}
   m_LocalPosition: {x: -0.023458017, y: -0.000007917646, z: -0.0035078856}
   m_LocalScale: {x: 0.9999999, y: 0.9999998, z: 0.99999976}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1474463604}
   m_Father: {fileID: 506715710}
@@ -10293,6 +10544,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.18333411, y: 4.013332e-17, z: -2.5364335e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 228237801}
   m_RootOrder: 0
@@ -10323,6 +10575,7 @@ Transform:
   m_LocalRotation: {x: -0.5071907, y: -0.49270436, z: -0.454019, w: 0.5420949}
   m_LocalPosition: {x: -0.12343654, y: 2.4047247e-17, z: -4.297936e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1284497236}
   m_RootOrder: 0
@@ -10353,6 +10606,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.049171697, w: 0.9987904}
   m_LocalPosition: {x: -0.09134354, y: 0.0017551515, z: -0.000000006891526}
   m_LocalScale: {x: 1.0000002, y: 1.0000002, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 789471901}
   - {fileID: 9718540}
@@ -10385,6 +10639,7 @@ Transform:
   m_LocalRotation: {x: 0.008016311, y: -0.09734142, z: 0.058641404, w: 0.9934896}
   m_LocalPosition: {x: -0.13752587, y: -4.6629366e-17, z: -6.106227e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1103808384}
   m_Father: {fileID: 1077784555}
@@ -10416,6 +10671,7 @@ Transform:
   m_LocalRotation: {x: 0.011196001, y: 0.99993575, z: 0.000012512218, w: 0.0017732558}
   m_LocalPosition: {x: 0.06083579, y: 0.0020787853, z: -0.072552614}
   m_LocalScale: {x: 1, y: 1.0000002, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 846160920}
   m_Father: {fileID: 563286634}
@@ -10449,6 +10705,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1403471705}
   m_RootOrder: 0
@@ -10522,6 +10779,7 @@ Transform:
   m_LocalRotation: {x: 0.69785506, y: 0.09374712, z: -0.060807347, w: 0.7074689}
   m_LocalPosition: {x: -0.0554337, y: 0.0017307289, z: -0.09865367}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 385376284}
   m_Father: {fileID: 504337346}
@@ -10553,6 +10811,7 @@ Transform:
   m_LocalRotation: {x: 0.84096724, y: 0.03311328, z: 0.5376023, w: 0.05158868}
   m_LocalPosition: {x: 0.029250061, y: 0.02684879, z: 0.0006188783}
   m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 95811608}
   m_Father: {fileID: 1648083170}
@@ -10584,6 +10843,7 @@ Transform:
   m_LocalRotation: {x: 0.000005962055, y: 0.0026267671, z: -0.000676907, w: 0.99999636}
   m_LocalPosition: {x: -0.055436894, y: -0.000000047903697, z: 0.00000091983424}
   m_LocalScale: {x: 0.9999999, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1420697592}
   m_Father: {fileID: 1508965623}
@@ -10616,6 +10876,7 @@ Transform:
   m_LocalRotation: {x: -0.47192225, y: 0.5467804, z: 0.45703635, w: 0.51907456}
   m_LocalPosition: {x: 1.2894577, y: -0.16327994, z: -0.01346737}
   m_LocalScale: {x: 1.0000006, y: 1.0000008, z: 1.000001}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1355326495}
   m_Father: {fileID: 1665962212}
@@ -10632,6 +10893,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -10706,6 +10968,7 @@ Transform:
   m_LocalRotation: {x: 0.0016610491, y: -0.08512243, z: 0.0005081766, w: 0.996369}
   m_LocalPosition: {x: -0.16248012, y: -0.0000006606469, z: 0.000001726818}
   m_LocalScale: {x: 1.0000001, y: 0.99999976, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 35429437}
   - {fileID: 1084053219}
@@ -10741,6 +11004,7 @@ Transform:
   m_LocalRotation: {x: 0.0969805, y: -0.016514864, z: -0.068927996, w: 0.9927593}
   m_LocalPosition: {x: -0.026287906, y: 0.001587632, z: -0.000030333284}
   m_LocalScale: {x: 1.0000021, y: 1.0000017, z: 1.0000019}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 392247028}
   m_RootOrder: 0
@@ -10771,6 +11035,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.1628788, y: -0.0000000020954543, z: 0.0000000016000674}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1573371846}
   m_RootOrder: 0
@@ -10802,6 +11067,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1833912637}
   m_RootOrder: 4
@@ -10817,6 +11083,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -10903,6 +11170,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.15087292, y: 6.7716e-17, z: 6.9388935e-19}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 588244140}
   m_RootOrder: 0
@@ -10933,6 +11201,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.14457126, y: -0.0008165151, z: -0.007399066}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 192391924}
   m_RootOrder: 0
@@ -10964,6 +11233,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1311595006}
   m_RootOrder: 4
@@ -10979,6 +11249,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -11065,6 +11336,7 @@ Transform:
   m_LocalRotation: {x: 0.00085945585, y: 0, z: -0, w: 0.99999964}
   m_LocalPosition: {x: -0.10291584, y: 7.566685e-18, z: -7.4712223e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1279668261}
   m_RootOrder: 0
@@ -11096,6 +11368,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1311595006}
   m_RootOrder: 13
@@ -11111,6 +11384,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -11223,6 +11497,7 @@ Transform:
   m_LocalRotation: {x: -0.005350928, y: -0.062506996, z: 0.121605895, w: 0.9905939}
   m_LocalPosition: {x: -0.14993033, y: 5.49367e-17, z: 7.480034e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 688562823}
   m_Father: {fileID: 481277443}
@@ -11254,6 +11529,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.10206909, y: -2.450161e-18, z: -3.9570888e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2021823621}
   m_RootOrder: 0
@@ -11285,6 +11561,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 800359998}
   m_RootOrder: 10
@@ -11300,6 +11577,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -11477,6 +11755,7 @@ Transform:
   m_LocalRotation: {x: -0.47192204, y: 0.5467805, z: 0.45703653, w: 0.51907444}
   m_LocalPosition: {x: 1.289459, y: -0.16328037, z: -0.013468142}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2045781770}
   m_RootOrder: 3
@@ -11492,6 +11771,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -11556,6 +11836,7 @@ Transform:
   m_LocalRotation: {x: 0.0033316321, y: -0.0169537, z: -0.0026204463, w: 0.9998473}
   m_LocalPosition: {x: -0.025226552, y: -0.00011562025, z: -0.0023841697}
   m_LocalScale: {x: 1.0000039, y: 1.0000029, z: 1.0000024}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2005841854}
   m_RootOrder: 0
@@ -11587,6 +11868,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 774205173}
   m_RootOrder: 0
@@ -11602,6 +11884,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -11684,6 +11967,7 @@ Transform:
   m_LocalRotation: {x: -0.47192225, y: 0.5467804, z: 0.45703635, w: 0.51907456}
   m_LocalPosition: {x: 1.2894577, y: -0.16327994, z: -0.01346737}
   m_LocalScale: {x: 1.0000006, y: 1.0000008, z: 1.000001}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 194713927}
   m_Father: {fileID: 2045781770}
@@ -11700,6 +11984,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -11774,6 +12059,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.15477863, y: 6.883383e-17, z: 1.2212453e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1461436307}
   m_RootOrder: 0
@@ -11804,6 +12090,7 @@ Transform:
   m_LocalRotation: {x: 0.055760637, y: 0.11511083, z: 0.06385369, w: 0.98972875}
   m_LocalPosition: {x: -0.08693589, y: -0.00055593316, z: -0.002243447}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2056470605}
   m_RootOrder: 0
@@ -11834,6 +12121,7 @@ Transform:
   m_LocalRotation: {x: -0.73015964, y: 0, z: 0, w: 0.6832766}
   m_LocalPosition: {x: -0.14825143, y: -0.010895066, z: 0.018342203}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 319981884}
   m_RootOrder: 0
@@ -11864,6 +12152,7 @@ Transform:
   m_LocalRotation: {x: -0.054846227, y: 0.006185361, z: 0.99130034, w: 0.11948777}
   m_LocalPosition: {x: -0.072350614, y: -0.041271094, z: 0.05315229}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 228237801}
   - {fileID: 346580924}
@@ -11896,6 +12185,7 @@ Transform:
   m_LocalRotation: {x: -0.73015964, y: 0, z: 0, w: 0.6832766}
   m_LocalPosition: {x: -0.14825143, y: -0.010895066, z: 0.018342203}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 461928817}
   m_RootOrder: 0
@@ -11927,6 +12217,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 774205173}
   m_RootOrder: 5
@@ -11942,6 +12233,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -12021,6 +12313,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 746900924}
   m_Father: {fileID: 1424463373}
@@ -12059,6 +12352,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1424463373}
   m_RootOrder: 4
@@ -12191,6 +12485,7 @@ Transform:
   m_LocalRotation: {x: -0.73015964, y: 0, z: 0, w: 0.6832766}
   m_LocalPosition: {x: -0.14825143, y: -0.010895066, z: 0.018342203}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 175254772}
   m_RootOrder: 0
@@ -12254,6 +12549,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -12302,6 +12598,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 3, y: 0.2, z: 3}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 954918647}
   m_RootOrder: 0
@@ -12332,6 +12629,7 @@ Transform:
   m_LocalRotation: {x: -0.0072285878, y: -0.0016318581, z: 0.15084802, w: 0.9885292}
   m_LocalPosition: {x: -0.08766678, y: -0.00030446955, z: -0.000000018569484}
   m_LocalScale: {x: 1.0000002, y: 1.0000004, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 86567734}
   - {fileID: 753311520}
@@ -12365,6 +12663,7 @@ Transform:
   m_LocalRotation: {x: -0.0000059582267, y: -0.00262653, z: -0.0006767927, w: 0.99999636}
   m_LocalPosition: {x: -0.055437315, y: -0.000000047463757, z: -0.0000009960296}
   m_LocalScale: {x: 1, y: 0.9999999, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1649063563}
   m_Father: {fileID: 316445541}
@@ -12397,6 +12696,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 774205173}
   m_RootOrder: 12
@@ -12412,6 +12712,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -12495,6 +12796,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.10206888, y: -0.000000016640396, z: -0.000000066199064}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1370251187}
   m_RootOrder: 0
@@ -12525,6 +12827,7 @@ Transform:
   m_LocalRotation: {x: -0.0018971404, y: 0.029820867, z: -0.057946537, w: 0.9978724}
   m_LocalPosition: {x: -0.032145437, y: 0.0019859255, z: 0.0015229473}
   m_LocalScale: {x: 0.99999994, y: 1.0000001, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1427773520}
   m_Father: {fileID: 1189488617}
@@ -12556,6 +12859,7 @@ Transform:
   m_LocalRotation: {x: -0.43375266, y: -0.5621338, z: -0.48488638, w: 0.51063645}
   m_LocalPosition: {x: -0.123436436, y: 1.2161711e-16, z: -2.5274234e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 401353977}
   m_RootOrder: 0
@@ -12586,6 +12890,7 @@ Transform:
   m_LocalRotation: {x: -0.008016839, y: 0.09734642, z: 0.058641255, w: 0.99348915}
   m_LocalPosition: {x: -0.13752584, y: 1.1990408e-16, z: -3.1086245e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2124865943}
   m_Father: {fileID: 553296276}
@@ -12617,6 +12922,7 @@ Transform:
   m_LocalRotation: {x: 0.9905085, y: 0.13556996, z: 0.022448432, w: 0.003137485}
   m_LocalPosition: {x: -0.041387863, y: -0.048911706, z: -0.012787029}
   m_LocalScale: {x: 0.9999999, y: 1.0000006, z: 1.0000008}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 46505223}
   m_Father: {fileID: 1635648789}
@@ -12648,6 +12954,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.18333411, y: 4.013332e-17, z: -2.5364335e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 631263512}
   m_RootOrder: 0
@@ -12680,6 +12987,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1894353744}
   m_RootOrder: 0
@@ -12753,6 +13061,7 @@ Transform:
   m_LocalRotation: {x: -0.43375266, y: -0.5621338, z: -0.48488638, w: 0.51063645}
   m_LocalPosition: {x: -0.123436436, y: 1.2161711e-16, z: -2.5274234e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1095543324}
   m_RootOrder: 0
@@ -12783,6 +13092,7 @@ Transform:
   m_LocalRotation: {x: 0.0067783757, y: 0.0029414739, z: -0.093876645, w: 0.9955564}
   m_LocalPosition: {x: -0.04704347, y: 0.036011066, z: -0.001029658}
   m_LocalScale: {x: 0.9999999, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 477711799}
   m_Father: {fileID: 2085037210}
@@ -12877,6 +13187,7 @@ Transform:
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
@@ -12907,6 +13218,7 @@ Transform:
   m_LocalRotation: {x: 0.0056376243, y: -0.03380472, z: 0.02410864, w: 0.9991217}
   m_LocalPosition: {x: -0.13229257, y: 3.7747583e-17, z: -1.0880185e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 121585296}
   m_Father: {fileID: 1885940304}
@@ -12938,6 +13250,7 @@ Transform:
   m_LocalRotation: {x: -0.7153496, y: -0.024095412, z: 0.023904901, w: 0.6979419}
   m_LocalPosition: {x: -0.021249697, y: 0.0010069837, z: 0.0016369896}
   m_LocalScale: {x: 1.0000044, y: 1.0000023, z: 1.0000025}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 920407375}
   m_RootOrder: 0
@@ -12968,6 +13281,7 @@ Transform:
   m_LocalRotation: {x: 0.008016311, y: -0.09734142, z: 0.058641404, w: 0.9934896}
   m_LocalPosition: {x: -0.13752587, y: -4.6629366e-17, z: -6.106227e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1461436307}
   m_Father: {fileID: 1237840066}
@@ -12999,6 +13313,7 @@ Transform:
   m_LocalRotation: {x: 0.43821856, y: -0.22390336, z: -0.16051973, w: 0.8556081}
   m_LocalPosition: {x: -0.026338825, y: 0.02086117, z: -0.0045268396}
   m_LocalScale: {x: 1.0000012, y: 1.0000008, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 990053586}
   m_Father: {fileID: 1966244813}
@@ -13030,6 +13345,7 @@ Transform:
   m_LocalRotation: {x: -0.5071907, y: -0.49270436, z: -0.454019, w: 0.5420949}
   m_LocalPosition: {x: -0.12343654, y: 2.4047247e-17, z: -4.297936e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2138379858}
   m_RootOrder: 0
@@ -13060,6 +13376,7 @@ Transform:
   m_LocalRotation: {x: -0.04601018, y: 0.9977064, z: 0.038900446, w: -0.03085172}
   m_LocalPosition: {x: -0.118353106, y: 0.11062721, z: -0.0006468265}
   m_LocalScale: {x: 1.0000006, y: 1.0000004, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 556438889}
   m_Father: {fileID: 791463027}
@@ -13092,6 +13409,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 774205173}
   m_RootOrder: 3
@@ -13107,6 +13425,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -13191,6 +13510,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 4, y: 4, z: 4}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2094560678}
   m_RootOrder: 0
@@ -13268,6 +13588,7 @@ Transform:
   m_LocalRotation: {x: -0.008649557, y: -0.0469462, z: -0.0062305992, w: 0.9988406}
   m_LocalPosition: {x: -0.07190759, y: 1.5543122e-17, z: 2.8607092e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1569607635}
   m_Father: {fileID: 1085230687}
@@ -13299,6 +13620,7 @@ Transform:
   m_LocalRotation: {x: -0.02557532, y: -0.010641737, z: 0.026150629, w: 0.99927413}
   m_LocalPosition: {x: -0.026304213, y: -0.0011438475, z: -0.00057086156}
   m_LocalScale: {x: 1.0000046, y: 1.0000029, z: 1.0000036}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1427773520}
   m_RootOrder: 0
@@ -13329,6 +13651,7 @@ Transform:
   m_LocalRotation: {x: -0.43375266, y: -0.5621338, z: -0.48488638, w: 0.51063645}
   m_LocalPosition: {x: -0.123436436, y: 1.2161711e-16, z: -2.5274234e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1283306690}
   m_RootOrder: 0
@@ -13359,6 +13682,7 @@ Transform:
   m_LocalRotation: {x: -0.0000025580453, y: 0.0000012854281, z: 0.016447844, w: 0.99986476}
   m_LocalPosition: {x: -0.35179782, y: -0.008010951, z: 0.0051462576}
   m_LocalScale: {x: 0.9999997, y: 0.99999976, z: 0.99999964}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1653001471}
   m_Father: {fileID: 1237647822}
@@ -13390,6 +13714,7 @@ Transform:
   m_LocalRotation: {x: -0.028078744, y: 0.033863522, z: -0.00080727146, w: 0.99903166}
   m_LocalPosition: {x: -0.024233012, y: -0.002230036, z: -0.0020085163}
   m_LocalScale: {x: 1, y: 0.99999976, z: 0.9999991}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1816503941}
   m_Father: {fileID: 35429437}
@@ -13421,6 +13746,7 @@ Transform:
   m_LocalRotation: {x: -0.028132368, y: -0.03407927, z: -0.0024114775, w: 0.9990202}
   m_LocalPosition: {x: -0.015907401, y: 0.00016659354, z: -0.00086091814}
   m_LocalScale: {x: 1.0000031, y: 1.0000023, z: 1.000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1140796200}
   m_Father: {fileID: 1502384429}
@@ -13452,6 +13778,7 @@ Transform:
   m_LocalRotation: {x: 0.15654893, y: 0.97501314, z: -0.017381625, w: 0.15665177}
   m_LocalPosition: {x: -0.09528863, y: 0.084203795, z: 0.08411823}
   m_LocalScale: {x: 1.0000006, y: 1.0000005, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1769472536}
   m_Father: {fileID: 1665962212}
@@ -13485,6 +13812,7 @@ Transform:
   m_LocalRotation: {x: -0.47192204, y: 0.5467805, z: 0.45703653, w: 0.51907444}
   m_LocalPosition: {x: 1.289459, y: -0.16328037, z: -0.013468142}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 791463027}
   m_RootOrder: 5
@@ -13500,6 +13828,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -13566,6 +13895,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 650801656}
   m_RootOrder: 0
@@ -13640,6 +13970,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 800359998}
   m_RootOrder: 3
@@ -13655,6 +13986,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -13737,6 +14069,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1750419230}
   m_Father: {fileID: 1912998594}
@@ -13768,6 +14101,7 @@ Transform:
   m_LocalRotation: {x: 0.007178454, y: 0.0018399023, z: -0.17932878, w: 0.9837613}
   m_LocalPosition: {x: -0.1568513, y: 0.008298479, z: 0.00028669508}
   m_LocalScale: {x: 1.0000005, y: 1.0000008, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1220662872}
   m_Father: {fileID: 675793193}
@@ -13799,6 +14133,7 @@ Transform:
   m_LocalRotation: {x: 0.6148564, y: 0.11044633, z: -0.013765099, w: 0.7807456}
   m_LocalPosition: {x: -0.04395507, y: 0.0027187055, z: 0.038988035}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1546693437}
   m_Father: {fileID: 1105383886}
@@ -13831,6 +14166,7 @@ Transform:
   m_LocalRotation: {x: -0.47192225, y: 0.5467804, z: 0.45703635, w: 0.51907456}
   m_LocalPosition: {x: 1.2894577, y: -0.16327994, z: -0.01346737}
   m_LocalScale: {x: 1.0000006, y: 1.0000008, z: 1.000001}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1461820354}
   m_Father: {fileID: 1220662872}
@@ -13847,6 +14183,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -13921,6 +14258,7 @@ Transform:
   m_LocalRotation: {x: -0.009559559, y: 0.011778613, z: -0.014041897, w: 0.9997863}
   m_LocalPosition: {x: -0.017586209, y: 0.0005113313, z: 0.000152205}
   m_LocalScale: {x: 1.0000015, y: 1.0000012, z: 1.0000017}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 802749722}
   m_Father: {fileID: 401326678}
@@ -13952,6 +14290,7 @@ Transform:
   m_LocalRotation: {x: 0.0022216337, y: 0.033948284, z: 0.021045804, w: 0.9991995}
   m_LocalPosition: {x: -0.14191042, y: -5.1481587e-17, z: -6.520502e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 154644733}
   m_Father: {fileID: 239980064}
@@ -13983,6 +14322,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.15087292, y: 6.7716e-17, z: 6.9388935e-19}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1312473507}
   m_RootOrder: 0
@@ -14013,6 +14353,7 @@ Transform:
   m_LocalRotation: {x: -0.111805744, y: 0.13116649, z: 0.20005274, w: 0.964507}
   m_LocalPosition: {x: -0.06575284, y: -0.027835598, z: -0.0022835932}
   m_LocalScale: {x: 1.0000018, y: 1.0000019, z: 1.0000012}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1921646633}
   m_Father: {fileID: 486394366}
@@ -14044,6 +14385,7 @@ Transform:
   m_LocalRotation: {x: 0.005350928, y: -0.061189618, z: 0.12227407, w: 0.9905939}
   m_LocalPosition: {x: 0.14993037, y: -0.000000002250124, z: -0.000000010045328}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1845719724}
   m_Father: {fileID: 242481518}
@@ -14075,6 +14417,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.15067062, y: -0.0078117703, z: 0.000000001284108}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2003163300}
   m_RootOrder: 0
@@ -14105,6 +14448,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 644043172}
   - {fileID: 1276872999}
@@ -14151,6 +14495,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1510974572}
   m_RootOrder: 0
@@ -14166,6 +14511,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -14240,6 +14586,7 @@ Transform:
   m_LocalRotation: {x: 0.6148564, y: 0.11044633, z: -0.013765099, w: 0.7807456}
   m_LocalPosition: {x: -0.04395507, y: 0.0027187055, z: 0.038988035}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1363669763}
   m_Father: {fileID: 1171642106}
@@ -14271,6 +14618,7 @@ Transform:
   m_LocalRotation: {x: 0.00007596266, y: -0.0017745967, z: -0.04276636, w: 0.9990835}
   m_LocalPosition: {x: -0.022713343, y: 0.008181497, z: -0.00008069934}
   m_LocalScale: {x: 1.0000002, y: 1.0000004, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 904776772}
   - {fileID: 1653114907}
@@ -14305,6 +14653,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1833912637}
   m_RootOrder: 0
@@ -14320,6 +14669,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -14401,6 +14751,7 @@ Transform:
   m_LocalRotation: {x: 0.0056376243, y: -0.03380472, z: 0.02410864, w: 0.9991217}
   m_LocalPosition: {x: -0.13229257, y: 3.7747583e-17, z: -1.0880185e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2063211963}
   m_Father: {fileID: 1195114949}
@@ -14432,6 +14783,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.15087292, y: 6.7716e-17, z: 6.9388935e-19}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1683885591}
   m_RootOrder: 0
@@ -14462,6 +14814,7 @@ Transform:
   m_LocalRotation: {x: -0.0072285878, y: -0.0016318581, z: 0.15084802, w: 0.9885292}
   m_LocalPosition: {x: -0.08766678, y: -0.00030446955, z: -0.000000018569484}
   m_LocalScale: {x: 1.0000002, y: 1.0000004, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1508965623}
   - {fileID: 1070548066}
@@ -14495,6 +14848,7 @@ Transform:
   m_LocalRotation: {x: 0.021434488, y: -0.005929963, z: 0.090837546, w: 0.9956174}
   m_LocalPosition: {x: -0.078083195, y: -0.0055345367, z: -0.0000000015732664}
   m_LocalScale: {x: 1.0000008, y: 1.0000006, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 829513726}
   - {fileID: 1321389774}
@@ -14542,6 +14896,7 @@ Transform:
   m_LocalRotation: {x: -0.47192204, y: 0.5467805, z: 0.45703653, w: 0.51907444}
   m_LocalPosition: {x: 1.289459, y: -0.16328037, z: -0.013468142}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1220662872}
   m_RootOrder: 4
@@ -14557,6 +14912,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -14621,6 +14977,7 @@ Transform:
   m_LocalRotation: {x: -0.09374654, y: 0.6978552, z: 0.70746905, w: 0.060806755}
   m_LocalPosition: {x: -0.05543403, y: 0.0017306843, z: 0.098653734}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 436181198}
   m_Father: {fileID: 504337346}
@@ -14652,6 +15009,7 @@ Transform:
   m_LocalRotation: {x: -0.023811344, y: 0.01439187, z: -0.5187163, w: 0.8544936}
   m_LocalPosition: {x: -0.084295675, y: 0.04771042, z: -0.0039216853}
   m_LocalScale: {x: 1.0000006, y: 0.9999997, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2031983873}
   m_RootOrder: 0
@@ -14684,6 +15042,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1885322429}
   m_RootOrder: 0
@@ -14757,6 +15116,7 @@ Transform:
   m_LocalRotation: {x: -0.010046666, y: -0.011496983, z: -0.0012787255, w: 0.99988264}
   m_LocalPosition: {x: -0.013910712, y: 0.0000027587055, z: 0.0002477763}
   m_LocalScale: {x: 1.0000038, y: 1.000003, z: 1.0000027}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1343429854}
   m_Father: {fileID: 1921646633}
@@ -14789,6 +15149,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 2.220446e-18, y: 0, z: -5.551115e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1311595006}
   m_RootOrder: 1
@@ -14804,6 +15165,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -14882,6 +15244,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2007154318}
   - {fileID: 1288304723}
@@ -14927,6 +15290,7 @@ Transform:
   m_LocalRotation: {x: 0.057060625, y: -0.015512465, z: 0.05145035, w: 0.99692345}
   m_LocalPosition: {x: -0.08069598, y: 0.0058216397, z: -0.0060212403}
   m_LocalScale: {x: 1.0000017, y: 1.0000018, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1148831859}
   m_Father: {fileID: 469796802}
@@ -14958,6 +15322,7 @@ Transform:
   m_LocalRotation: {x: 0.0969805, y: -0.016514864, z: -0.068927996, w: 0.9927593}
   m_LocalPosition: {x: -0.026287906, y: 0.001587632, z: -0.000030333284}
   m_LocalScale: {x: 1.0000021, y: 1.0000017, z: 1.0000019}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 758367463}
   m_RootOrder: 0
@@ -15006,6 +15371,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -15054,6 +15420,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: -1, z: 0}
   m_LocalScale: {x: 30, y: 30, z: 30}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2
@@ -15084,6 +15451,7 @@ Transform:
   m_LocalRotation: {x: -0.028132368, y: -0.03407927, z: -0.0024114775, w: 0.9990202}
   m_LocalPosition: {x: -0.015907401, y: 0.00016659354, z: -0.00086091814}
   m_LocalScale: {x: 1.0000031, y: 1.0000023, z: 1.000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1458308843}
   m_Father: {fileID: 1918581711}
@@ -15115,6 +15483,7 @@ Transform:
   m_LocalRotation: {x: 0.0022216337, y: 0.033948284, z: 0.021045804, w: 0.9991995}
   m_LocalPosition: {x: -0.14191042, y: -5.1481587e-17, z: -6.520502e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 189845853}
   m_Father: {fileID: 1246447102}
@@ -15146,6 +15515,7 @@ Transform:
   m_LocalRotation: {x: -0.054846227, y: 0.006185361, z: 0.99130034, w: 0.11948777}
   m_LocalPosition: {x: -0.072350614, y: -0.041271094, z: 0.05315229}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 968970583}
   - {fileID: 575402331}
@@ -15178,6 +15548,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.10206909, y: -2.450161e-18, z: -3.9570888e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 346580924}
   m_RootOrder: 0
@@ -15209,6 +15580,7 @@ Transform:
   m_LocalRotation: {x: -0.47192225, y: 0.5467804, z: 0.45703635, w: 0.51907456}
   m_LocalPosition: {x: 1.2894577, y: -0.16327994, z: -0.01346737}
   m_LocalScale: {x: 1.0000006, y: 1.0000008, z: 1.000001}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1220662872}
   m_RootOrder: 0
@@ -15224,6 +15596,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -15297,6 +15670,7 @@ Transform:
   m_LocalRotation: {x: 0.50088733, y: -0.4991111, z: -0.4991111, w: 0.50088733}
   m_LocalPosition: {x: -0, y: 0.86858183, z: 0.011826879}
   m_LocalScale: {x: 0.9999992, y: 0.9999991, z: 0.9999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 465768723}
   - {fileID: 422411307}
@@ -15334,6 +15708,7 @@ Transform:
   m_LocalRotation: {x: 0.0022775515, y: -0.010616068, z: -0.0041946047, w: 0.9999323}
   m_LocalPosition: {x: -0.02426037, y: 0.0025070603, z: -0.0011865995}
   m_LocalScale: {x: 0.9999998, y: 0.99999976, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 965901615}
   m_Father: {fileID: 216615211}
@@ -15365,6 +15740,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1552731364}
   m_Father: {fileID: 283419386}
@@ -15401,6 +15777,7 @@ Transform:
   m_LocalRotation: {x: -0.02156939, y: -0.07812919, z: -0.015850486, w: 0.9965839}
   m_LocalPosition: {x: -0.023458017, y: -0.000007917646, z: -0.0035078856}
   m_LocalScale: {x: 0.9999999, y: 0.9999998, z: 0.99999976}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2108850526}
   m_Father: {fileID: 1740396549}
@@ -15433,6 +15810,7 @@ Transform:
   m_LocalRotation: {x: -0.47192225, y: 0.5467804, z: 0.45703635, w: 0.51907456}
   m_LocalPosition: {x: 1.2894577, y: -0.16327994, z: -0.01346737}
   m_LocalScale: {x: 1.0000006, y: 1.0000008, z: 1.000001}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 791463027}
   m_RootOrder: 0
@@ -15448,6 +15826,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -15522,6 +15901,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1311595006}
   m_RootOrder: 0
@@ -15537,6 +15917,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -15618,6 +15999,7 @@ Transform:
   m_LocalRotation: {x: -0.0018971404, y: 0.029820867, z: -0.057946537, w: 0.9978724}
   m_LocalPosition: {x: -0.032145437, y: 0.0019859255, z: 0.0015229473}
   m_LocalScale: {x: 0.99999994, y: 1.0000001, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1360638655}
   m_Father: {fileID: 1694353219}
@@ -15649,6 +16031,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.15477823, y: 7.5495166e-17, z: -6.383782e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 354467952}
   m_RootOrder: 0
@@ -15683,6 +16066,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 3, y: 0.2, z: 3}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1516828407}
   m_RootOrder: 0
@@ -15726,6 +16110,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -15790,6 +16175,7 @@ Transform:
   m_LocalRotation: {x: -0.11370098, y: 0.97812754, z: -0.16029842, w: -0.0681406}
   m_LocalPosition: {x: -0.118646674, y: 0.109952554, z: -0.007276585}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 941897049}
   m_Father: {fileID: 791463027}
@@ -15821,6 +16207,7 @@ Transform:
   m_LocalRotation: {x: 0.017632259, y: 0.014270657, z: -0.00057296036, w: 0.99974257}
   m_LocalPosition: {x: -0.013885546, y: 0.0002669609, z: 0.00082812016}
   m_LocalScale: {x: 1.000002, y: 1.0000019, z: 1.0000018}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1033402649}
   m_Father: {fileID: 464757794}
@@ -15854,6 +16241,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 283419386}
   m_RootOrder: 0
@@ -15927,6 +16315,7 @@ Transform:
   m_LocalRotation: {x: -0.0043129246, y: 0.02031516, z: 0.019814534, w: 0.99958795}
   m_LocalPosition: {x: -0.13655789, y: -2.184919e-15, z: 3.2862602e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1237840066}
   m_Father: {fileID: 1458144128}
@@ -15958,6 +16347,7 @@ Transform:
   m_LocalRotation: {x: -0.0000073946076, y: -0.0000015158422, z: 0.016451556, w: 0.9998647}
   m_LocalPosition: {x: -0.35136372, y: -0.0080112815, z: -0.018233713}
   m_LocalScale: {x: 1.0000002, y: 1.0000002, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 991104488}
   m_Father: {fileID: 611929951}
@@ -15989,6 +16379,7 @@ Transform:
   m_LocalRotation: {x: 0.00012215874, y: -0.00051764084, z: 0.0027444, w: 0.9999961}
   m_LocalPosition: {x: -0.11597514, y: 6.217249e-17, z: -2.5535128e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1811189548}
   m_Father: {fileID: 2131921689}
@@ -16020,6 +16411,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.15067062, y: -0.0078117703, z: 0.000000001284108}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1244503852}
   m_RootOrder: 0
@@ -16050,6 +16442,7 @@ Transform:
   m_LocalRotation: {x: 0.1631833, y: 0.97231275, z: -0.025657691, w: -0.16529022}
   m_LocalPosition: {x: -0.09799041, y: 0.07704446, z: -0.0877954}
   m_LocalScale: {x: 1.0000006, y: 1.0000005, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 920338942}
   m_Father: {fileID: 2045781770}
@@ -16081,6 +16474,7 @@ Transform:
   m_LocalRotation: {x: 0.017632259, y: 0.014270657, z: -0.00057296036, w: 0.99974257}
   m_LocalPosition: {x: -0.013885546, y: 0.0002669609, z: 0.00082812016}
   m_LocalScale: {x: 1.000002, y: 1.0000019, z: 1.0000018}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 989552743}
   m_Father: {fileID: 200516198}
@@ -16112,6 +16506,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.10206888, y: -0.000000016640396, z: -0.000000066199064}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 412768721}
   m_RootOrder: 0
@@ -16144,6 +16539,7 @@ Transform:
   m_LocalRotation: {x: -0.47192204, y: 0.5467805, z: 0.45703653, w: 0.51907444}
   m_LocalPosition: {x: 1.289459, y: -0.16328037, z: -0.013468142}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2045781770}
   m_RootOrder: 1
@@ -16159,6 +16555,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -16223,6 +16620,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.049171697, w: 0.9987904}
   m_LocalPosition: {x: -0.09134354, y: 0.0017551515, z: -0.000000006891526}
   m_LocalScale: {x: 1.0000002, y: 1.0000002, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1009839551}
   - {fileID: 340343233}
@@ -16255,6 +16653,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.10206888, y: -0.000000016640396, z: -0.000000066199064}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1611941086}
   m_RootOrder: 0
@@ -16285,6 +16684,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.049171697, w: 0.9987904}
   m_LocalPosition: {x: -0.09134354, y: 0.0017551515, z: -0.000000006891526}
   m_LocalScale: {x: 1.0000002, y: 1.0000002, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 373212390}
   - {fileID: 15058952}
@@ -16317,6 +16717,7 @@ Transform:
   m_LocalRotation: {x: -0.0018971404, y: 0.029820867, z: -0.057946537, w: 0.9978724}
   m_LocalPosition: {x: -0.032145437, y: 0.0019859255, z: 0.0015229473}
   m_LocalScale: {x: 0.99999994, y: 1.0000001, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2014733666}
   m_Father: {fileID: 1367597432}
@@ -16348,6 +16749,7 @@ Transform:
   m_LocalRotation: {x: -0.008649557, y: -0.0469462, z: -0.0062305992, w: 0.9988406}
   m_LocalPosition: {x: -0.07190759, y: 1.5543122e-17, z: 2.8607092e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 300915465}
   m_Father: {fileID: 886376508}
@@ -16379,6 +16781,7 @@ Transform:
   m_LocalRotation: {x: 0.002749186, y: -0.061828945, z: 0.0046093785, w: 0.9980723}
   m_LocalPosition: {x: -0.016096681, y: 0.000118210985, z: -0.00045832127}
   m_LocalScale: {x: 1.0000032, y: 1.0000025, z: 1.000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 707378283}
   m_Father: {fileID: 446319708}
@@ -16410,6 +16813,7 @@ Transform:
   m_LocalRotation: {x: -0.111805744, y: 0.13116649, z: 0.20005274, w: 0.964507}
   m_LocalPosition: {x: -0.06575284, y: -0.027835598, z: -0.0022835932}
   m_LocalScale: {x: 1.0000018, y: 1.0000019, z: 1.0000012}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1055042377}
   m_Father: {fileID: 1410784690}
@@ -16441,6 +16845,7 @@ Transform:
   m_LocalRotation: {x: -0.028078744, y: 0.033863522, z: -0.00080727146, w: 0.99903166}
   m_LocalPosition: {x: -0.024233012, y: -0.002230036, z: -0.0020085163}
   m_LocalScale: {x: 1, y: 0.99999976, z: 0.9999991}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1203157335}
   m_Father: {fileID: 981654183}
@@ -16475,6 +16880,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2063147047}
   m_Father: {fileID: 1052524564}
@@ -16617,6 +17023,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.15067062, y: -0.0078117703, z: 0.000000001284108}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1417284377}
   m_RootOrder: 0
@@ -16647,6 +17054,7 @@ Transform:
   m_LocalRotation: {x: -0.111805744, y: 0.13116649, z: 0.20005274, w: 0.964507}
   m_LocalPosition: {x: -0.06575284, y: -0.027835598, z: -0.0022835932}
   m_LocalScale: {x: 1.0000018, y: 1.0000019, z: 1.0000012}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1971264170}
   m_Father: {fileID: 99827840}
@@ -16678,6 +17086,7 @@ Transform:
   m_LocalRotation: {x: 0.03296851, y: 0.011079731, z: 0.00012965832, w: 0.999395}
   m_LocalPosition: {x: -0.032029476, y: 0.0011279538, z: 0.0006024109}
   m_LocalScale: {x: 0.9999999, y: 0.99999976, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 392247028}
   m_Father: {fileID: 1075737120}
@@ -16709,6 +17118,7 @@ Transform:
   m_LocalRotation: {x: 0.08809389, y: 0.23000443, z: 0.29465634, w: 0.92331743}
   m_LocalPosition: {x: -0.17970763, y: 0.08956378, z: 0.041412033}
   m_LocalScale: {x: 1.0000005, y: 1.0000007, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 413746500}
   m_Father: {fileID: 1665962212}
@@ -16740,6 +17150,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.14457126, y: -0.0008165151, z: -0.007399066}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 185938420}
   m_RootOrder: 0
@@ -16770,6 +17181,7 @@ Transform:
   m_LocalRotation: {x: 0.49999982, y: -0.50000024, z: -0.4999999, w: -0.5000001}
   m_LocalPosition: {x: 0, y: -1, z: -0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 175330856}
   m_RootOrder: 1
@@ -16800,6 +17212,7 @@ Transform:
   m_LocalRotation: {x: -0.051157355, y: -0.01140533, z: 0.009748385, w: 0.9985779}
   m_LocalPosition: {x: -0.062838286, y: -0.00004745255, z: -0.0014896186}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 833964354}
   m_RootOrder: 0
@@ -16830,6 +17243,7 @@ Transform:
   m_LocalRotation: {x: -0.10604028, y: -0.697103, z: -0.11625049, w: 0.69949174}
   m_LocalPosition: {x: -0.122454844, y: -0.00014976753, z: -0.041993644}
   m_LocalScale: {x: 1.0000011, y: 1.000001, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1789958546}
   m_Father: {fileID: 789471901}
@@ -16861,6 +17275,7 @@ Transform:
   m_LocalRotation: {x: 0.00010815607, y: -0.0073533887, z: -0.05896039, w: 0.99823326}
   m_LocalPosition: {x: 0.0000000018666693, y: -0.000000030172764, z: -2.8229039e-10}
   m_LocalScale: {x: 0.99999946, y: 0.99999946, z: 0.99999964}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1611773918}
   m_Father: {fileID: 1246447102}
@@ -16892,6 +17307,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -7.6100006, y: -1, z: 11.05}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 666075242}
   - {fileID: 1066235440}
@@ -16925,6 +17341,7 @@ Transform:
   m_LocalRotation: {x: 0.000005962055, y: 0.0026267671, z: -0.000676907, w: 0.99999636}
   m_LocalPosition: {x: -0.055436894, y: -0.000000047903697, z: 0.00000091983424}
   m_LocalScale: {x: 0.9999999, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1105383886}
   m_Father: {fileID: 321630486}
@@ -17009,6 +17426,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -1.65, y: 3.1, z: -2.71}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -17039,6 +17457,7 @@ Transform:
   m_LocalRotation: {x: 0.011196001, y: 0.99993575, z: 0.000012512218, w: 0.0017732558}
   m_LocalPosition: {x: 0.06083579, y: 0.0020787853, z: -0.072552614}
   m_LocalScale: {x: 1, y: 1.0000002, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1129974861}
   m_Father: {fileID: 1750419230}
@@ -17070,6 +17489,7 @@ Transform:
   m_LocalRotation: {x: 0.002749186, y: -0.061828945, z: 0.0046093785, w: 0.9980723}
   m_LocalPosition: {x: -0.016096681, y: 0.000118210985, z: -0.00045832127}
   m_LocalScale: {x: 1.0000032, y: 1.0000025, z: 1.000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1655552549}
   m_Father: {fileID: 819069943}
@@ -17102,6 +17522,7 @@ Transform:
   m_LocalRotation: {x: -0.47192225, y: 0.5467804, z: 0.45703635, w: 0.51907456}
   m_LocalPosition: {x: 1.2894577, y: -0.16327994, z: -0.01346737}
   m_LocalScale: {x: 1.0000006, y: 1.0000008, z: 1.000001}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2045781770}
   m_RootOrder: 0
@@ -17117,6 +17538,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -17190,6 +17612,7 @@ Transform:
   m_LocalRotation: {x: -0.55629134, y: -0.41471907, z: 0.11797892, w: 0.71037245}
   m_LocalPosition: {x: -0.08505593, y: -1.0880185e-16, z: -1.2434498e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1690190911}
   m_Father: {fileID: 1500782407}
@@ -17222,6 +17645,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 2.220446e-18, y: 0, z: -5.551115e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1833912637}
   m_RootOrder: 1
@@ -17237,6 +17661,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -17315,6 +17740,7 @@ Transform:
   m_LocalRotation: {x: 0.10428145, y: 0.04083601, z: 0.0008412449, w: 0.9937088}
   m_LocalPosition: {x: -0.08074935, y: 0.025713358, z: -0.001428291}
   m_LocalScale: {x: 1.0000013, y: 1.0000015, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 172356952}
   m_Father: {fileID: 486394366}
@@ -17346,6 +17772,7 @@ Transform:
   m_LocalRotation: {x: -0.005350928, y: -0.062506996, z: 0.121605895, w: 0.9905939}
   m_LocalPosition: {x: -0.14993033, y: 5.49367e-17, z: 7.480034e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1559987774}
   m_Father: {fileID: 806950728}
@@ -17379,6 +17806,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1709218426}
   m_RootOrder: 4
@@ -17511,6 +17939,7 @@ Transform:
   m_LocalRotation: {x: -0.00012399502, y: 0.00052538066, z: 0.00273948, w: 0.9999961}
   m_LocalPosition: {x: -0.11597685, y: 9.7699626e-17, z: 1.7208457e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1195114949}
   m_Father: {fileID: 2109491000}
@@ -17542,6 +17971,7 @@ Transform:
   m_LocalRotation: {x: 0.99050975, y: 0.13555767, z: -0.022467816, w: -0.0031346574}
   m_LocalPosition: {x: -0.041389998, y: -0.048910234, z: 0.012788884}
   m_LocalScale: {x: 1.0000011, y: 1.0000005, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1993333625}
   m_Father: {fileID: 1420697592}
@@ -17573,6 +18003,7 @@ Transform:
   m_LocalRotation: {x: 0.017483843, y: 0.9998472, z: 5.8411366e-17, w: 1.6185826e-16}
   m_LocalPosition: {x: 0.18568334, y: -0.007424814, z: 0.00000047303573}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 252231457}
   m_Father: {fileID: 302818384}
@@ -17604,6 +18035,7 @@ Transform:
   m_LocalRotation: {x: -0.02557532, y: -0.010641737, z: 0.026150629, w: 0.99927413}
   m_LocalPosition: {x: -0.026304213, y: -0.0011438475, z: -0.00057086156}
   m_LocalScale: {x: 1.0000046, y: 1.0000029, z: 1.0000036}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1390862513}
   m_RootOrder: 0
@@ -17634,6 +18066,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.15087292, y: 6.7716e-17, z: 6.9388935e-19}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1801262636}
   m_RootOrder: 0
@@ -17664,6 +18097,7 @@ Transform:
   m_LocalRotation: {x: 0.99590546, y: -0.01934041, z: -0.041608024, w: -0.07789138}
   m_LocalPosition: {x: -0.07745903, y: 0.024773534, z: 0.02387737}
   m_LocalScale: {x: 1.0000012, y: 1.0000013, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 924369977}
   m_Father: {fileID: 1611882741}
@@ -17696,6 +18130,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1833912637}
   m_RootOrder: 9
@@ -17711,6 +18146,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -17801,6 +18237,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -3.6212335e-11, y: 0.0374364, z: 0.039560296}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1648083170}
   m_RootOrder: 1
@@ -17831,6 +18268,7 @@ Transform:
   m_LocalRotation: {x: -0.014208467, y: -0.0082518505, z: -0.017708749, w: 0.9997082}
   m_LocalPosition: {x: -0.019202955, y: 0.0005186548, z: -0.0002499818}
   m_LocalScale: {x: 1.0000023, y: 1.000002, z: 1.0000015}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 894592975}
   m_RootOrder: 0
@@ -17861,6 +18299,7 @@ Transform:
   m_LocalRotation: {x: 0.03296851, y: 0.011079731, z: 0.00012965832, w: 0.999395}
   m_LocalPosition: {x: -0.032029476, y: 0.0011279538, z: 0.0006024109}
   m_LocalScale: {x: 0.9999999, y: 0.99999976, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2062853382}
   m_Father: {fileID: 710533174}
@@ -17892,6 +18331,7 @@ Transform:
   m_LocalRotation: {x: 0.0000005580623, y: -0.0000024002752, z: -0.26428223, w: 0.9644454}
   m_LocalPosition: {x: -0.3785454, y: 0.0038244387, z: -0.010314554}
   m_LocalScale: {x: 0.9999998, y: 0.9999996, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 337026252}
   m_Father: {fileID: 846160920}
@@ -17927,6 +18367,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 1}
   m_LocalScale: {x: 0.005, y: 0.005, z: 0.005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1935541667}
   - {fileID: 2023630874}
@@ -18042,6 +18483,7 @@ Transform:
   m_LocalRotation: {x: 0.43821856, y: -0.22390336, z: -0.16051973, w: 0.8556081}
   m_LocalPosition: {x: -0.026338825, y: 0.02086117, z: -0.0045268396}
   m_LocalScale: {x: 1.0000012, y: 1.0000008, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1441449727}
   m_Father: {fileID: 1611882741}
@@ -18073,6 +18515,7 @@ Transform:
   m_LocalRotation: {x: -0.3695515, y: 0, z: 0, w: 0.92921025}
   m_LocalPosition: {x: 0, y: 0.54045296, z: -0.8993217}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1066235440}
   m_RootOrder: 5
@@ -18107,6 +18550,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 1}
   m_LocalScale: {x: 0.005, y: 0.005, z: 0.005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2094560678}
   - {fileID: 1885322429}
@@ -18222,6 +18666,7 @@ Transform:
   m_LocalRotation: {x: -0.0072285878, y: -0.0016318581, z: 0.15084802, w: 0.9885292}
   m_LocalPosition: {x: -0.08766678, y: -0.00030446955, z: -0.000000018569484}
   m_LocalScale: {x: 1.0000002, y: 1.0000004, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 321630486}
   - {fileID: 2042610384}
@@ -18256,6 +18701,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 800359998}
   m_RootOrder: 5
@@ -18271,6 +18717,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -18350,6 +18797,7 @@ Transform:
   m_LocalRotation: {x: 0.024406396, y: -0.040521923, z: -0.013085931, w: 0.99879485}
   m_LocalPosition: {x: -0.018097645, y: -0.00014428438, z: -0.00005280069}
   m_LocalScale: {x: 1.0000018, y: 1.0000017, z: 1.0000018}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 542983569}
   m_Father: {fileID: 1881830146}
@@ -18383,6 +18831,7 @@ Transform:
   m_LocalRotation: {x: -0.47192204, y: 0.5467805, z: 0.45703653, w: 0.51907444}
   m_LocalPosition: {x: 1.289459, y: -0.16328037, z: -0.013468142}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1665962212}
   m_RootOrder: 3
@@ -18398,6 +18847,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -18462,6 +18912,7 @@ Transform:
   m_LocalRotation: {x: 0.0067783757, y: 0.0029414739, z: -0.093876645, w: 0.9955564}
   m_LocalPosition: {x: -0.04704347, y: 0.036011066, z: -0.001029658}
   m_LocalScale: {x: 0.9999999, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1426811511}
   m_Father: {fileID: 165006370}
@@ -18493,6 +18944,7 @@ Transform:
   m_LocalRotation: {x: 0.024370978, y: -0.06598202, z: -0.008131702, w: 0.99749}
   m_LocalPosition: {x: -0.021437468, y: -0.000471134, z: -0.0050665224}
   m_LocalScale: {x: 1.000002, y: 1.000002, z: 1.0000015}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1211573431}
   m_RootOrder: 0
@@ -18523,6 +18975,7 @@ Transform:
   m_LocalRotation: {x: -0.000123844, y: 0.00104117, z: -0.00042751798, w: 0.99999934}
   m_LocalPosition: {x: -0.23377718, y: 0.000017186263, z: 0.0000117539585}
   m_LocalScale: {x: 0.99999994, y: 0.9999998, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 469796802}
   - {fileID: 461928817}
@@ -18558,6 +19011,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1208958413}
   m_Father: {fileID: 1709218426}
@@ -18594,6 +19048,7 @@ Transform:
   m_LocalRotation: {x: -0.014208467, y: -0.0082518505, z: -0.017708749, w: 0.9997082}
   m_LocalPosition: {x: -0.019202955, y: 0.0005186548, z: -0.0002499818}
   m_LocalScale: {x: 1.0000023, y: 1.000002, z: 1.0000015}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 836970271}
   m_RootOrder: 0
@@ -18625,6 +19080,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 774205173}
   m_RootOrder: 14
@@ -18640,6 +19096,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -18752,6 +19209,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.15477823, y: 7.5495166e-17, z: -6.383782e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 117320079}
   m_RootOrder: 0
@@ -18847,6 +19305,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 1}
   m_LocalScale: {x: 0.005, y: 0.005, z: 0.005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 925209235}
   - {fileID: 1424463373}
@@ -18901,6 +19360,7 @@ Transform:
   m_LocalRotation: {x: 0.018954959, y: -0.016845439, z: 0.022771137, w: 0.99941903}
   m_LocalPosition: {x: -0.01809678, y: 0.00013280302, z: -0.000014452478}
   m_LocalScale: {x: 1.0000025, y: 1.0000023, z: 1.0000019}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 190125197}
   m_Father: {fileID: 923601058}
@@ -18933,6 +19393,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 774205173}
   m_RootOrder: 8
@@ -18948,6 +19409,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -19072,6 +19534,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1235737973}
   m_Father: {fileID: 57266860}
@@ -19110,6 +19573,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 476798957}
   m_RootOrder: 0
@@ -19186,6 +19650,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: 3, y: 0, z: 3}
   m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 384090246}
   - {fileID: 289608957}
@@ -19214,6 +19679,7 @@ MonoBehaviour:
   TransitionSetting:
     OutputTargetWeight: 1
     FadeInTime: 0.2
+    FixedTimeOffset: 0
     ExitTime: 0
     ClipSpeed: 1
     RestartWhenPlay: 1
@@ -19234,7 +19700,7 @@ MonoBehaviour:
   m_customFrameRate: 15
 --- !u!95 &1066235443
 Animator:
-  serializedVersion: 3
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -19247,10 +19713,12 @@ Animator:
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!1 &1070548065
 GameObject:
   m_ObjectHideFlags: 0
@@ -19277,6 +19745,7 @@ Transform:
   m_LocalRotation: {x: 0.007178454, y: 0.0018399023, z: -0.17932878, w: 0.9837613}
   m_LocalPosition: {x: -0.1568513, y: 0.008298479, z: 0.00028669508}
   m_LocalScale: {x: 1.0000005, y: 1.0000008, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1665962212}
   m_Father: {fileID: 789471901}
@@ -19308,6 +19777,7 @@ Transform:
   m_LocalRotation: {x: -0.7060321, y: -0.084708445, z: -0.037965525, w: 0.70206964}
   m_LocalPosition: {x: -0.043953944, y: 0.0027083214, z: -0.038982198}
   m_LocalScale: {x: 0.9999999, y: 1.0000012, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1703342013}
   m_Father: {fileID: 1635648789}
@@ -19339,6 +19809,7 @@ Transform:
   m_LocalRotation: {x: 0.018954959, y: -0.016845439, z: 0.022771137, w: 0.99941903}
   m_LocalPosition: {x: -0.01809678, y: 0.00013280302, z: -0.000014452478}
   m_LocalScale: {x: 1.0000025, y: 1.0000023, z: 1.0000019}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2143572289}
   m_Father: {fileID: 1497008485}
@@ -19370,6 +19841,7 @@ Transform:
   m_LocalRotation: {x: -0.028078744, y: 0.033863522, z: -0.00080727146, w: 0.99903166}
   m_LocalPosition: {x: -0.024233012, y: -0.002230036, z: -0.0020085163}
   m_LocalScale: {x: 1, y: 0.99999976, z: 0.9999991}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1543789197}
   m_Father: {fileID: 2032648716}
@@ -19401,6 +19873,7 @@ Transform:
   m_LocalRotation: {x: 0.43821856, y: -0.22390336, z: -0.16051973, w: 0.8556081}
   m_LocalPosition: {x: -0.026338825, y: 0.02086117, z: -0.0045268396}
   m_LocalScale: {x: 1.0000012, y: 1.0000008, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 931783302}
   m_Father: {fileID: 617037369}
@@ -19432,6 +19905,7 @@ Transform:
   m_LocalRotation: {x: 0.004313685, y: -0.020318924, z: 0.019809484, w: 0.999588}
   m_LocalPosition: {x: -0.13656151, y: 1.110223e-16, z: -5.5511148e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 553296276}
   m_Father: {fileID: 379444779}
@@ -19463,6 +19937,7 @@ Transform:
   m_LocalRotation: {x: 0.0056376243, y: -0.03380472, z: 0.02410864, w: 0.9991217}
   m_LocalPosition: {x: -0.13229257, y: 3.7747583e-17, z: -1.0880185e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 610029387}
   m_Father: {fileID: 1797031831}
@@ -19494,6 +19969,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 497258969}
   m_Father: {fileID: 1709218426}
@@ -19531,6 +20007,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1833912637}
   m_RootOrder: 5
@@ -19546,6 +20023,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -19625,6 +20103,7 @@ Transform:
   m_LocalRotation: {x: 0.9944477, y: 0.028325185, z: -0.06578186, w: -0.077098854}
   m_LocalPosition: {x: -0.07734096, y: 0.004360036, z: 0.024110846}
   m_LocalScale: {x: 1.0000012, y: 1.0000014, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1830304563}
   m_Father: {fileID: 617037369}
@@ -19656,6 +20135,7 @@ Transform:
   m_LocalRotation: {x: 0.1631833, y: 0.97231275, z: -0.025657691, w: -0.16529022}
   m_LocalPosition: {x: -0.09799041, y: 0.07704446, z: -0.0877954}
   m_LocalScale: {x: 1.0000006, y: 1.0000005, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 719929682}
   m_Father: {fileID: 1665962212}
@@ -19689,6 +20169,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 4, y: 4, z: 4}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 457922243}
   m_RootOrder: 0
@@ -19767,6 +20248,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 774205173}
   m_RootOrder: 2
@@ -19782,6 +20264,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -19863,6 +20346,7 @@ Transform:
   m_LocalRotation: {x: 0.02212266, y: 0.9988644, z: -0.0009343224, w: -0.042185765}
   m_LocalPosition: {x: -0.0684722, y: 0.07501754, z: -0.057344463}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 599455052}
   - {fileID: 1095543324}
@@ -19895,6 +20379,7 @@ Transform:
   m_LocalRotation: {x: -0.000108155284, y: 0.0073531894, z: -0.058960136, w: 0.99823326}
   m_LocalPosition: {x: -1.4210854e-16, y: -3.5527136e-17, z: -1.7763568e-17}
   m_LocalScale: {x: 0.99999946, y: 0.99999946, z: 0.99999964}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 702046837}
   m_Father: {fileID: 1092965446}
@@ -19926,6 +20411,7 @@ Transform:
   m_LocalRotation: {x: 0.06180407, y: -0.113891736, z: -0.0007837494, w: 0.9915686}
   m_LocalPosition: {x: -0.021074723, y: -0.00070411974, z: -0.0032540236}
   m_LocalScale: {x: 1.0000017, y: 1.0000018, z: 1.0000014}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1543789197}
   m_RootOrder: 0
@@ -19956,6 +20442,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.16287886, y: 0.000000027959265, z: 0.000000003748803}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 362524472}
   m_RootOrder: 0
@@ -19986,6 +20473,7 @@ Transform:
   m_LocalRotation: {x: -0.00013146584, y: -0.013670889, z: 0.032817043, w: 0.9993679}
   m_LocalPosition: {x: -0.1459784, y: -4.6629366e-17, z: -2.4528989e-17}
   m_LocalScale: {x: 1.0000007, y: 1.0000002, z: 1.0000007}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 598008501}
   m_Father: {fileID: 610029387}
@@ -20017,6 +20505,7 @@ Transform:
   m_LocalRotation: {x: -0.000123844, y: 0.00104117, z: -0.00042751798, w: 0.99999934}
   m_LocalPosition: {x: -0.23377718, y: 0.000017186263, z: 0.0000117539585}
   m_LocalScale: {x: 0.99999994, y: 0.9999998, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1410784690}
   - {fileID: 2035742064}
@@ -20052,6 +20541,7 @@ Transform:
   m_LocalRotation: {x: 0.1631833, y: 0.97231275, z: -0.025657691, w: -0.16529022}
   m_LocalPosition: {x: -0.09799041, y: 0.07704446, z: -0.0877954}
   m_LocalScale: {x: 1.0000006, y: 1.0000005, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1151441209}
   m_Father: {fileID: 1220662872}
@@ -20083,6 +20573,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 1.3399997, y: -1, z: 11.05}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 179577088}
   - {fileID: 337441687}
@@ -20116,6 +20607,7 @@ Transform:
   m_LocalRotation: {x: 0.02212266, y: 0.9988644, z: -0.0009343224, w: -0.042185765}
   m_LocalPosition: {x: -0.0684722, y: 0.07501754, z: -0.057344463}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 312536625}
   - {fileID: 1283306690}
@@ -20148,6 +20640,7 @@ Transform:
   m_LocalRotation: {x: 0.9641222, y: 0.08804348, z: 0.08698386, w: -0.23484161}
   m_LocalPosition: {x: -0.07430402, y: -0.013710743, z: 0.01965605}
   m_LocalScale: {x: 1.0000013, y: 1.0000014, z: 1.0000008}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 422009571}
   m_Father: {fileID: 617037369}
@@ -20179,6 +20672,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1527363807}
   m_Father: {fileID: 1885322429}
@@ -20216,6 +20710,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 774205173}
   m_RootOrder: 9
@@ -20231,6 +20726,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -20321,6 +20817,7 @@ Transform:
   m_LocalRotation: {x: -0.0000073946076, y: -0.0000015158422, z: 0.016451556, w: 0.9998647}
   m_LocalPosition: {x: -0.35136372, y: -0.0080112815, z: -0.018233713}
   m_LocalScale: {x: 1.0000002, y: 1.0000002, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1650031966}
   m_Father: {fileID: 964777226}
@@ -20352,6 +20849,7 @@ Transform:
   m_LocalRotation: {x: -0.02156939, y: -0.07812919, z: -0.015850486, w: 0.9965839}
   m_LocalPosition: {x: -0.023458017, y: -0.000007917646, z: -0.0035078856}
   m_LocalScale: {x: 0.9999999, y: 0.9999998, z: 0.99999976}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1440787313}
   m_Father: {fileID: 1317693310}
@@ -20383,6 +20881,7 @@ Transform:
   m_LocalRotation: {x: 0.0221195, y: 0.9987083, z: 0.0010128983, w: 0.045732945}
   m_LocalPosition: {x: -0.068878286, y: 0.07501759, z: 0.056856666}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1279668261}
   - {fileID: 140022228}
@@ -20415,6 +20914,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -3.6212335e-11, y: 0.0374364, z: 0.039560296}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 9718540}
   m_RootOrder: 1
@@ -20446,6 +20946,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1833912637}
   m_RootOrder: 2
@@ -20461,6 +20962,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -20542,6 +21044,7 @@ Transform:
   m_LocalRotation: {x: 0.056542903, y: 0.7048425, z: -0.056542903, w: 0.7048425}
   m_LocalPosition: {x: 0.1630146, y: 0.0000034868867, z: 0.00000009529151}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1229604190}
   m_RootOrder: 0
@@ -20572,6 +21075,7 @@ Transform:
   m_LocalRotation: {x: 0.0033316321, y: -0.0169537, z: -0.0026204463, w: 0.9998473}
   m_LocalPosition: {x: -0.025226552, y: -0.00011562025, z: -0.0023841697}
   m_LocalScale: {x: 1.0000039, y: 1.0000029, z: 1.0000024}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 734533613}
   m_RootOrder: 0
@@ -20602,6 +21106,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 536828247}
   m_Father: {fileID: 231704635}
@@ -20638,6 +21143,7 @@ Transform:
   m_LocalRotation: {x: -0.7059503, y: 0.03399268, z: 0.0064747767, w: 0.7074155}
   m_LocalPosition: {x: -0.022013659, y: 0.0009110151, z: 0.00011725739}
   m_LocalScale: {x: 1.0000029, y: 1.0000014, z: 1.0000017}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 556145870}
   m_RootOrder: 0
@@ -20668,6 +21174,7 @@ Transform:
   m_LocalRotation: {x: -0.03357769, y: 0.06963723, z: -0.014093166, w: 0.99690753}
   m_LocalPosition: {x: -0.025063124, y: 0.0014819854, z: 0.00379354}
   m_LocalScale: {x: 1, y: 0.99999994, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 518729703}
   m_Father: {fileID: 800839278}
@@ -20699,6 +21206,7 @@ Transform:
   m_LocalRotation: {x: -0.008649557, y: -0.0469462, z: -0.0062305992, w: 0.9988406}
   m_LocalPosition: {x: -0.07190759, y: 1.5543122e-17, z: 2.8607092e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1274991385}
   m_Father: {fileID: 1106919583}
@@ -20730,6 +21238,7 @@ Transform:
   m_LocalRotation: {x: 0.00012215874, y: -0.00051764084, z: 0.0027444, w: 0.9999961}
   m_LocalPosition: {x: -0.11597514, y: 6.217249e-17, z: -2.5535128e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 143524504}
   m_Father: {fileID: 1164708388}
@@ -20761,6 +21270,7 @@ Transform:
   m_LocalRotation: {x: -0.09374654, y: 0.6978552, z: 0.70746905, w: 0.060806755}
   m_LocalPosition: {x: -0.05543403, y: 0.0017306843, z: 0.098653734}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1283281668}
   m_Father: {fileID: 468706479}
@@ -20792,6 +21302,7 @@ Transform:
   m_LocalRotation: {x: 0.017483843, y: 0.9998472, z: 0.000000007449441, w: 1.3026479e-10}
   m_LocalPosition: {x: -0.18568392, y: 0.007427308, z: -2.6214969e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7554462}
   m_Father: {fileID: 2124587144}
@@ -20823,6 +21334,7 @@ Transform:
   m_LocalRotation: {x: 0.1008327, y: 0.026525343, z: 0.9770472, w: 0.18576309}
   m_LocalPosition: {x: -0.033491675, y: -0.07271498, z: -0.058596842}
   m_LocalScale: {x: 1.0000008, y: 1.0000007, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1154624516}
   m_Father: {fileID: 1665962212}
@@ -20854,6 +21366,7 @@ Transform:
   m_LocalRotation: {x: 0.06540314, y: 0, z: 0, w: 0.99785894}
   m_LocalPosition: {x: 0, y: 1.25, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1066235440}
   m_RootOrder: 3
@@ -20884,6 +21397,7 @@ Transform:
   m_LocalRotation: {x: -0.000032017142, y: -0.00005018094, z: -0.51892006, w: 0.85482275}
   m_LocalPosition: {x: -0.08439235, y: 0.047660332, z: 0.0020256662}
   m_LocalScale: {x: 0.99999994, y: 0.99999946, z: 0.9999996}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 401353169}
   m_RootOrder: 0
@@ -20914,6 +21428,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.15477823, y: 7.5495166e-17, z: -6.383782e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1941409541}
   m_RootOrder: 0
@@ -20944,6 +21459,7 @@ Transform:
   m_LocalRotation: {x: -0.000123844, y: 0.00104117, z: -0.00042751798, w: 0.99999934}
   m_LocalPosition: {x: -0.23377718, y: 0.000017186263, z: 0.0000117539585}
   m_LocalScale: {x: 0.99999994, y: 0.9999998, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 99827840}
   - {fileID: 175254772}
@@ -20979,6 +21495,7 @@ Transform:
   m_LocalRotation: {x: 0.10428145, y: 0.04083601, z: 0.0008412449, w: 0.9937088}
   m_LocalPosition: {x: -0.08074935, y: 0.025713358, z: -0.001428291}
   m_LocalScale: {x: 1.0000013, y: 1.0000015, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1245057946}
   m_Father: {fileID: 1410784690}
@@ -21012,6 +21529,7 @@ Transform:
   m_LocalRotation: {x: -0.47192204, y: 0.5467805, z: 0.45703653, w: 0.51907444}
   m_LocalPosition: {x: 1.289459, y: -0.16328037, z: -0.013468142}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1665962212}
   m_RootOrder: 1
@@ -21027,6 +21545,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -21091,6 +21610,7 @@ Transform:
   m_LocalRotation: {x: -0.000000008911413, y: 0.99850297, z: -0.05469786, w: -0.00000016267678}
   m_LocalPosition: {x: 0.1, y: 1.3677425, z: 2.6517928}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 337441687}
   m_RootOrder: 4
@@ -21121,6 +21641,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.14476337, y: 0.000000011632276, z: -0.0000000060625056}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1887532643}
   m_RootOrder: 0
@@ -21151,6 +21672,7 @@ Transform:
   m_LocalRotation: {x: 0.81400937, y: -0.09669037, z: -0.3280601, w: 0.4694852}
   m_LocalPosition: {x: -0.024760697, y: 0.01826633, z: 0.01423601}
   m_LocalScale: {x: 1.0000014, y: 1.0000014, z: 1.0000019}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 683864195}
   m_Father: {fileID: 99827840}
@@ -21184,6 +21706,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1604956581}
   m_RootOrder: 0
@@ -21257,6 +21780,7 @@ Transform:
   m_LocalRotation: {x: -0.0043129246, y: 0.02031516, z: 0.019814534, w: 0.99958795}
   m_LocalPosition: {x: -0.13655789, y: -2.184919e-15, z: 3.2862602e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 785855631}
   m_Father: {fileID: 972793718}
@@ -21288,6 +21812,7 @@ Transform:
   m_LocalRotation: {x: -0.014208467, y: -0.0082518505, z: -0.017708749, w: 0.9997082}
   m_LocalPosition: {x: -0.019202955, y: 0.0005186548, z: -0.0002499818}
   m_LocalScale: {x: 1.0000023, y: 1.000002, z: 1.0000015}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 542983569}
   m_RootOrder: 0
@@ -21318,6 +21843,7 @@ Transform:
   m_LocalRotation: {x: 0.0067783757, y: 0.0029414739, z: -0.093876645, w: 0.9955564}
   m_LocalPosition: {x: -0.04704347, y: 0.036011066, z: -0.001029658}
   m_LocalScale: {x: 0.9999999, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2013470147}
   m_Father: {fileID: 1635648789}
@@ -21349,6 +21875,7 @@ Transform:
   m_LocalRotation: {x: -0.038566142, y: -0.0144198695, z: -0.0068944027, w: 0.9991282}
   m_LocalPosition: {x: -0.015886165, y: 0.0000011769014, z: -0.0026419829}
   m_LocalScale: {x: 1.0000015, y: 1.0000019, z: 1.0000019}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 411162573}
   m_Father: {fileID: 924369977}
@@ -21380,6 +21907,7 @@ Transform:
   m_LocalRotation: {x: 0.5562991, y: 0.41471618, z: 0.11796325, w: 0.71037066}
   m_LocalPosition: {x: -0.08505328, y: -1.6764368e-16, z: 1.1990408e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 420475056}
   m_Father: {fileID: 1931908646}
@@ -21411,6 +21939,7 @@ Transform:
   m_LocalRotation: {x: 0.49999982, y: -0.50000024, z: -0.4999999, w: -0.5000001}
   m_LocalPosition: {x: 0, y: -1, z: -0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1912998594}
   m_RootOrder: 1
@@ -21443,6 +21972,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1032011843}
   m_RootOrder: 0
@@ -21516,6 +22046,7 @@ Transform:
   m_LocalRotation: {x: 0.69785506, y: 0.09374712, z: -0.060807347, w: 0.7074689}
   m_LocalPosition: {x: -0.0554337, y: 0.0017307289, z: -0.09865367}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1539108839}
   m_Father: {fileID: 468706479}
@@ -21547,6 +22078,7 @@ Transform:
   m_LocalRotation: {x: 0.004569878, y: 0.041777767, z: 0.001183233, w: 0.99911577}
   m_LocalPosition: {x: -0.019415826, y: -0.00041664625, z: -0.0007046589}
   m_LocalScale: {x: 1.0000017, y: 1.0000015, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1029771598}
   m_Father: {fileID: 1830304563}
@@ -21578,6 +22110,7 @@ Transform:
   m_LocalRotation: {x: 0.0066097225, y: 0.051325165, z: -0.11946504, w: 0.9914889}
   m_LocalPosition: {x: -0.071971275, y: -0.041271117, z: -0.05366487}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 307125089}
   - {fileID: 1611941086}
@@ -21610,6 +22143,7 @@ Transform:
   m_LocalRotation: {x: 0.021434488, y: -0.005929963, z: 0.090837546, w: 0.9956174}
   m_LocalPosition: {x: -0.078083195, y: -0.0055345367, z: -0.0000000015732664}
   m_LocalScale: {x: 1.0000008, y: 1.0000006, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 807563469}
   - {fileID: 108368726}
@@ -21655,6 +22189,7 @@ Transform:
   m_LocalRotation: {x: 0.017483843, y: 0.9998472, z: 5.8411366e-17, w: 1.6185826e-16}
   m_LocalPosition: {x: 0.18568334, y: -0.007424814, z: 0.00000047303573}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1138599390}
   m_Father: {fileID: 1913851485}
@@ -21686,6 +22221,7 @@ Transform:
   m_LocalRotation: {x: 0.49999982, y: -0.50000024, z: -0.4999999, w: -0.5000001}
   m_LocalPosition: {x: 0, y: -1, z: -0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 337441687}
   m_RootOrder: 1
@@ -21718,6 +22254,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1061324379}
   m_RootOrder: 0
@@ -21791,6 +22328,7 @@ Transform:
   m_LocalRotation: {x: 0.011179984, y: 0.99979585, z: 0.00023534863, w: -0.016828509}
   m_LocalPosition: {x: 0.06031916, y: 0.0020788328, z: 0.07298301}
   m_LocalScale: {x: 1.0000004, y: 1.0000005, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 726432428}
   m_Father: {fileID: 1750419230}
@@ -21822,6 +22360,7 @@ Transform:
   m_LocalRotation: {x: 0.0056376243, y: -0.03380472, z: 0.02410864, w: 0.9991217}
   m_LocalPosition: {x: -0.13229257, y: 3.7747583e-17, z: -1.0880185e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 708041729}
   m_Father: {fileID: 845572721}
@@ -21853,6 +22392,7 @@ Transform:
   m_LocalRotation: {x: -0.051157355, y: -0.01140533, z: 0.009748385, w: 0.9985779}
   m_LocalPosition: {x: -0.062838286, y: -0.00004745255, z: -0.0014896186}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 203597068}
   m_RootOrder: 0
@@ -21883,6 +22423,7 @@ Transform:
   m_LocalRotation: {x: 0.70492166, y: 0.054471448, z: -0.05372531, w: 0.70514673}
   m_LocalPosition: {x: -0.044249896, y: 0.00025344297, z: 0.03772974}
   m_LocalScale: {x: 0.9999999, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 876961707}
   m_Father: {fileID: 1635648789}
@@ -21914,6 +22455,7 @@ Transform:
   m_LocalRotation: {x: 0.0022775515, y: -0.010616068, z: -0.0041946047, w: 0.9999323}
   m_LocalPosition: {x: -0.02426037, y: 0.0025070603, z: -0.0011865995}
   m_LocalScale: {x: 0.9999998, y: 0.99999976, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1900531318}
   m_Father: {fileID: 1172062532}
@@ -21945,6 +22487,7 @@ Transform:
   m_LocalRotation: {x: 0.008649987, y: 0.046947528, z: -0.0062286453, w: 0.9988405}
   m_LocalPosition: {x: -0.07190698, y: -3.593991e-18, z: -4.7696836e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 101921927}
   m_Father: {fileID: 1767436536}
@@ -21976,6 +22519,7 @@ Transform:
   m_LocalRotation: {x: 0.0221195, y: 0.9987083, z: 0.0010128983, w: 0.045732945}
   m_LocalPosition: {x: -0.068878286, y: 0.07501759, z: 0.056856666}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 806422321}
   - {fileID: 951516282}
@@ -22008,6 +22552,7 @@ Transform:
   m_LocalRotation: {x: -0.00012399502, y: 0.00052538066, z: 0.00273948, w: 0.9999961}
   m_LocalPosition: {x: -0.11597685, y: 9.7699626e-17, z: 1.7208457e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1797031831}
   m_Father: {fileID: 222182316}
@@ -22039,6 +22584,7 @@ Transform:
   m_LocalRotation: {x: 0.5562991, y: 0.41471618, z: 0.11796325, w: 0.71037066}
   m_LocalPosition: {x: -0.08505328, y: -1.6764368e-16, z: 1.1990408e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1882625674}
   m_Father: {fileID: 1773117739}
@@ -22070,6 +22616,7 @@ Transform:
   m_LocalRotation: {x: -0.0056373896, y: 0.03380287, z: 0.024109717, w: 0.9991218}
   m_LocalPosition: {x: -0.13228849, y: -1.1324275e-16, z: -1.1268764e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1891178740}
   m_Father: {fileID: 1905692506}
@@ -22101,6 +22648,7 @@ Transform:
   m_LocalRotation: {x: -0.009046391, y: 0.021917243, z: 0.025727285, w: 0.9993878}
   m_LocalPosition: {x: -0.015893577, y: -0.0010325513, z: 0.0003781104}
   m_LocalScale: {x: 1.0000015, y: 1.0000017, z: 1.0000015}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 374204053}
   m_Father: {fileID: 422009571}
@@ -22132,6 +22680,7 @@ Transform:
   m_LocalRotation: {x: -0.3895228, y: 0.5901459, z: -0.51284444, w: -0.48681676}
   m_LocalPosition: {x: -0.07073497, y: 3.330669e-17, z: -1.1213252e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1151441209}
   m_RootOrder: 0
@@ -22164,6 +22713,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1424463373}
   m_RootOrder: 3
@@ -22300,6 +22850,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
   m_HorizontalAxis: Horizontal
   m_VerticalAxis: Vertical
   m_SubmitButton: Submit
@@ -22332,6 +22883,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 3
@@ -22363,6 +22915,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 2.220446e-18, y: 0, z: -5.551115e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 774205173}
   m_RootOrder: 1
@@ -22378,6 +22931,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -22456,6 +23010,7 @@ Transform:
   m_LocalRotation: {x: 0.0022216337, y: 0.033948284, z: 0.021045804, w: 0.9991995}
   m_LocalPosition: {x: -0.14191042, y: -5.1481587e-17, z: -6.520502e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 627667899}
   m_Father: {fileID: 1134315401}
@@ -22487,6 +23042,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.10206909, y: -2.450161e-18, z: -3.9570888e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 575402331}
   m_RootOrder: 0
@@ -22517,6 +23073,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.09931355, y: 0.009804863, z: 0.0015692349}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1155104052}
   m_RootOrder: 0
@@ -22547,6 +23104,7 @@ Transform:
   m_LocalRotation: {x: -0.000108155284, y: 0.0073531894, z: -0.058960136, w: 0.99823326}
   m_LocalPosition: {x: -1.4210854e-16, y: -3.5527136e-17, z: -1.7763568e-17}
   m_LocalScale: {x: 0.99999946, y: 0.99999946, z: 0.99999964}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 723868115}
   m_Father: {fileID: 1109097618}
@@ -22578,6 +23136,7 @@ Transform:
   m_LocalRotation: {x: 0.00010815607, y: -0.0073533887, z: -0.05896039, w: 0.99823326}
   m_LocalPosition: {x: 0.0000000018666693, y: -0.000000030172764, z: -2.8229039e-10}
   m_LocalScale: {x: 0.99999946, y: 0.99999946, z: 0.99999964}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 604361737}
   m_Father: {fileID: 1922074311}
@@ -22610,6 +23169,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 2.220446e-18, y: 0, z: -5.551115e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 800359998}
   m_RootOrder: 1
@@ -22625,6 +23185,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -22703,6 +23264,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.14900754, y: -0.013332438, z: 0.007244749}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1398705784}
   m_RootOrder: 0
@@ -22733,6 +23295,7 @@ Transform:
   m_LocalRotation: {x: -0.022844326, y: -0.05376183, z: 0.017722234, w: 0.99813515}
   m_LocalPosition: {x: -0.01943113, y: -0.00006783814, z: 0.00016170353}
   m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 223663261}
   m_Father: {fileID: 556119843}
@@ -22765,6 +23328,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 774205173}
   m_RootOrder: 10
@@ -22780,6 +23344,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -22955,6 +23520,7 @@ Transform:
   m_LocalRotation: {x: 0.007178454, y: 0.0018399023, z: -0.17932878, w: 0.9837613}
   m_LocalPosition: {x: -0.1568513, y: 0.008298479, z: 0.00028669508}
   m_LocalScale: {x: 1.0000005, y: 1.0000008, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2045781770}
   m_Father: {fileID: 373212390}
@@ -22986,6 +23552,7 @@ Transform:
   m_LocalRotation: {x: -0.04601018, y: 0.9977064, z: 0.038900446, w: -0.03085172}
   m_LocalPosition: {x: -0.118353106, y: 0.11062721, z: -0.0006468265}
   m_LocalScale: {x: 1.0000006, y: 1.0000004, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 117678205}
   m_Father: {fileID: 1220662872}
@@ -23017,6 +23584,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 830671323}
   - {fileID: 797077004}
@@ -23062,6 +23630,7 @@ Transform:
   m_LocalRotation: {x: -0.70609546, y: -0.036204185, z: -0.035443116, w: 0.7063018}
   m_LocalPosition: {x: -0.044251043, y: 0.00025278676, z: -0.037730616}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 769898627}
   m_Father: {fileID: 1420697592}
@@ -23093,6 +23662,7 @@ Transform:
   m_LocalRotation: {x: 0.9641222, y: 0.08804348, z: 0.08698386, w: -0.23484161}
   m_LocalPosition: {x: -0.07430402, y: -0.013710743, z: 0.01965605}
   m_LocalScale: {x: 1.0000013, y: 1.0000014, z: 1.0000008}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1133106177}
   m_Father: {fileID: 1966244813}
@@ -23126,6 +23696,7 @@ Transform:
   m_LocalRotation: {x: -0.47192204, y: 0.5467805, z: 0.45703653, w: 0.51907444}
   m_LocalPosition: {x: 1.289459, y: -0.16328037, z: -0.013468142}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 791463027}
   m_RootOrder: 1
@@ -23141,6 +23712,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -23207,6 +23779,7 @@ Transform:
   m_LocalRotation: {x: -0.47192204, y: 0.5467805, z: 0.45703653, w: 0.51907444}
   m_LocalPosition: {x: 1.289459, y: -0.16328037, z: -0.013468142}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1665962212}
   m_RootOrder: 5
@@ -23222,6 +23795,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -23286,6 +23860,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.09931355, y: 0.009804863, z: 0.0015692349}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1653114907}
   m_RootOrder: 0
@@ -23316,6 +23891,7 @@ Transform:
   m_LocalRotation: {x: 0.02212266, y: 0.9988644, z: -0.0009343224, w: -0.042185765}
   m_LocalPosition: {x: -0.0684722, y: 0.07501754, z: -0.057344463}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 25958704}
   - {fileID: 1813948891}
@@ -23348,6 +23924,7 @@ Transform:
   m_LocalRotation: {x: -0.022844326, y: -0.05376183, z: 0.017722234, w: 0.99813515}
   m_LocalPosition: {x: -0.01943113, y: -0.00006783814, z: 0.00016170353}
   m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2020422262}
   m_Father: {fileID: 2128587110}
@@ -23379,6 +23956,7 @@ Transform:
   m_LocalRotation: {x: -0.0478358, y: -0.0038424567, z: 0.0030543627, w: 0.9988432}
   m_LocalPosition: {x: -0.01920933, y: -0.00029923706, z: -0.00002337768}
   m_LocalScale: {x: 1.0000054, y: 1.0000043, z: 1.0000037}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 796320436}
   m_RootOrder: 0
@@ -23409,6 +23987,7 @@ Transform:
   m_LocalRotation: {x: 0.1631833, y: 0.97231275, z: -0.025657691, w: -0.16529022}
   m_LocalPosition: {x: -0.09799041, y: 0.07704446, z: -0.0877954}
   m_LocalScale: {x: 1.0000006, y: 1.0000005, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2115573014}
   m_Father: {fileID: 791463027}
@@ -23441,6 +24020,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 616855788}
   m_RootOrder: 0
@@ -23456,6 +24036,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -23530,6 +24111,7 @@ Transform:
   m_LocalRotation: {x: 0.005350928, y: -0.061189618, z: 0.12227407, w: 0.9905939}
   m_LocalPosition: {x: 0.14993037, y: -0.000000002250124, z: -0.000000010045328}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 462864224}
   m_Father: {fileID: 379840832}
@@ -23561,6 +24143,7 @@ Transform:
   m_LocalRotation: {x: -0.0931137, y: 0.017067054, z: 0.97876835, w: 0.1817996}
   m_LocalPosition: {x: -0.03154395, y: -0.06754832, z: 0.06546028}
   m_LocalScale: {x: 1.000001, y: 1.0000007, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 49639835}
   m_Father: {fileID: 791463027}
@@ -23592,6 +24175,7 @@ Transform:
   m_LocalRotation: {x: 0.00047884785, y: 0.014813263, z: 0.03715169, w: 0.99919975}
   m_LocalPosition: {x: -0.017565973, y: -0.0010033782, z: 0.000084740605}
   m_LocalScale: {x: 1.0000027, y: 1.0000021, z: 1.0000026}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 294343899}
   m_Father: {fileID: 830713524}
@@ -23623,6 +24207,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.14457126, y: -0.0008165151, z: -0.007399066}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 781656333}
   m_RootOrder: 0
@@ -23653,6 +24238,7 @@ Transform:
   m_LocalRotation: {x: -0.0000059582267, y: -0.00262653, z: -0.0006767927, w: 0.99999636}
   m_LocalPosition: {x: -0.055437315, y: -0.000000047463757, z: -0.0000009960296}
   m_LocalScale: {x: 1, y: 0.9999999, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1635648789}
   m_Father: {fileID: 542355293}
@@ -23684,6 +24270,7 @@ Transform:
   m_LocalRotation: {x: 0.81400937, y: -0.09669037, z: -0.3280601, w: 0.4694852}
   m_LocalPosition: {x: -0.024760697, y: 0.01826633, z: 0.01423601}
   m_LocalScale: {x: 1.0000014, y: 1.0000014, z: 1.0000019}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 915671414}
   m_Father: {fileID: 486394366}
@@ -23715,6 +24302,7 @@ Transform:
   m_LocalRotation: {x: 0.02212266, y: 0.9988644, z: -0.0009343224, w: -0.042185765}
   m_LocalPosition: {x: -0.0684722, y: 0.07501754, z: -0.057344463}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1961057263}
   - {fileID: 401353977}
@@ -23747,6 +24335,7 @@ Transform:
   m_LocalRotation: {x: 0.003306259, y: 0.044774983, z: -0.02161404, w: 0.9987578}
   m_LocalPosition: {x: -0, y: -7.105427e-17, z: 1.7763568e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 680951630}
   m_Father: {fileID: 242481518}
@@ -23778,6 +24367,7 @@ Transform:
   m_LocalRotation: {x: -0.518709, y: 0.071315005, z: -0.14153358, w: 0.84013295}
   m_LocalPosition: {x: -0.07073235, y: 5.4780847e-17, z: -8.082631e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1379732629}
   m_RootOrder: 0
@@ -23808,6 +24398,7 @@ Transform:
   m_LocalRotation: {x: 0.008649987, y: 0.046947528, z: -0.0062286453, w: 0.9988405}
   m_LocalPosition: {x: -0.07190698, y: -3.593991e-18, z: -4.7696836e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1373288831}
   m_Father: {fileID: 1473616211}
@@ -23839,6 +24430,7 @@ Transform:
   m_LocalRotation: {x: -0.3695515, y: 0, z: 0, w: 0.92921025}
   m_LocalPosition: {x: 0, y: 0.54045296, z: -0.8993217}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 337441687}
   m_RootOrder: 5
@@ -23871,6 +24463,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 283419386}
   m_RootOrder: 4
@@ -24003,6 +24596,7 @@ Transform:
   m_LocalRotation: {x: 0.00047884785, y: 0.014813263, z: 0.03715169, w: 0.99919975}
   m_LocalPosition: {x: -0.017565973, y: -0.0010033782, z: 0.000084740605}
   m_LocalScale: {x: 1.0000027, y: 1.0000021, z: 1.0000026}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 974072217}
   m_Father: {fileID: 1706158802}
@@ -24035,6 +24629,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 800359998}
   m_RootOrder: 8
@@ -24050,6 +24645,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -24174,6 +24770,7 @@ Transform:
   m_LocalRotation: {x: 0.0067783757, y: 0.0029414739, z: -0.093876645, w: 0.9955564}
   m_LocalPosition: {x: -0.04704347, y: 0.036011066, z: -0.001029658}
   m_LocalScale: {x: 0.9999999, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1289626640}
   m_Father: {fileID: 1649063563}
@@ -24207,6 +24804,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 283419386}
   m_RootOrder: 3
@@ -24343,6 +24941,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 1}
   m_LocalScale: {x: 0.005, y: 0.005, z: 0.005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 457922243}
   - {fileID: 283419386}
@@ -24459,6 +25058,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 612427528}
   - {fileID: 458647785}
@@ -24563,6 +25163,7 @@ Transform:
   m_LocalRotation: {x: 0.06180407, y: -0.113891736, z: -0.0007837494, w: 0.9915686}
   m_LocalPosition: {x: -0.021074723, y: -0.00070411974, z: -0.0032540236}
   m_LocalScale: {x: 1.0000017, y: 1.0000018, z: 1.0000014}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 582258092}
   m_RootOrder: 0
@@ -24593,6 +25194,7 @@ Transform:
   m_LocalRotation: {x: -0.10604028, y: -0.697103, z: -0.11625049, w: 0.69949174}
   m_LocalPosition: {x: -0.122454844, y: -0.00014976753, z: -0.041993644}
   m_LocalScale: {x: 1.0000011, y: 1.000001, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 295616006}
   m_Father: {fileID: 1009839551}
@@ -24624,6 +25226,7 @@ Transform:
   m_LocalRotation: {x: -0.10859549, y: -0.021866571, z: -0.0013553738, w: 0.99384457}
   m_LocalPosition: {x: -0.16248195, y: -0.0000006351125, z: 0.00000024924654}
   m_LocalScale: {x: 1.0000014, y: 1.0000011, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1172062532}
   - {fileID: 469274532}
@@ -24659,6 +25262,7 @@ Transform:
   m_LocalRotation: {x: 0.70492166, y: 0.054471448, z: -0.05372531, w: 0.70514673}
   m_LocalPosition: {x: -0.044249896, y: 0.00025344297, z: 0.03772974}
   m_LocalScale: {x: 0.9999999, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 926262849}
   m_Father: {fileID: 1649063563}
@@ -24690,6 +25294,7 @@ Transform:
   m_LocalRotation: {x: -0.3895228, y: 0.5901459, z: -0.51284444, w: -0.48681676}
   m_LocalPosition: {x: -0.07073497, y: 3.330669e-17, z: -1.1213252e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2115573014}
   m_RootOrder: 0
@@ -24720,6 +25325,7 @@ Transform:
   m_LocalRotation: {x: -0.000123844, y: 0.00104117, z: -0.00042751798, w: 0.99999934}
   m_LocalPosition: {x: -0.23377718, y: 0.000017186263, z: 0.0000117539585}
   m_LocalScale: {x: 0.99999994, y: 0.9999998, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 486394366}
   - {fileID: 319981884}
@@ -24757,6 +25363,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1885322429}
   m_RootOrder: 3
@@ -24890,6 +25497,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1894170740}
   - {fileID: 650801656}
@@ -24993,6 +25601,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.14900754, y: -0.013332438, z: 0.007244749}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1029736165}
   m_RootOrder: 0
@@ -25023,6 +25632,7 @@ Transform:
   m_LocalRotation: {x: 0.00047884785, y: 0.014813263, z: 0.03715169, w: 0.99919975}
   m_LocalPosition: {x: -0.017565973, y: -0.0010033782, z: 0.000084740605}
   m_LocalScale: {x: 1.0000027, y: 1.0000021, z: 1.0000026}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 722559675}
   m_Father: {fileID: 683864195}
@@ -25054,6 +25664,7 @@ Transform:
   m_LocalRotation: {x: -0.0478358, y: -0.0038424567, z: 0.0030543627, w: 0.9988432}
   m_LocalPosition: {x: -0.01920933, y: -0.00029923706, z: -0.00002337768}
   m_LocalScale: {x: 1.0000054, y: 1.0000043, z: 1.0000037}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 190125197}
   m_RootOrder: 0
@@ -25084,6 +25695,7 @@ Transform:
   m_LocalRotation: {x: -0.12178339, y: -0.20300739, z: 0.30530372, w: 0.92235917}
   m_LocalPosition: {x: -0.18103224, y: 0.08604571, z: -0.04305515}
   m_LocalScale: {x: 1.0000005, y: 1.0000007, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1826440316}
   m_Father: {fileID: 1220662872}
@@ -25117,6 +25729,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1885322429}
   m_RootOrder: 4
@@ -25249,6 +25862,7 @@ Transform:
   m_LocalRotation: {x: -0.009046391, y: 0.021917243, z: 0.025727285, w: 0.9993878}
   m_LocalPosition: {x: -0.015893577, y: -0.0010325513, z: 0.0003781104}
   m_LocalScale: {x: 1.0000015, y: 1.0000017, z: 1.0000015}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 274694661}
   m_Father: {fileID: 1133106177}
@@ -25280,6 +25894,7 @@ Transform:
   m_LocalRotation: {x: 0.03296851, y: 0.011079731, z: 0.00012965832, w: 0.999395}
   m_LocalPosition: {x: -0.032029476, y: 0.0011279538, z: 0.0006024109}
   m_LocalScale: {x: 0.9999999, y: 0.99999976, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1524767899}
   m_Father: {fileID: 1002687146}
@@ -25312,6 +25927,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1833912637}
   m_RootOrder: 3
@@ -25327,6 +25943,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -25409,6 +26026,7 @@ Transform:
   m_LocalRotation: {x: 0.1008327, y: 0.026525343, z: 0.9770472, w: 0.18576309}
   m_LocalPosition: {x: -0.033491675, y: -0.07271498, z: -0.058596842}
   m_LocalScale: {x: 1.0000008, y: 1.0000007, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 379444779}
   m_Father: {fileID: 791463027}
@@ -25440,6 +26058,7 @@ Transform:
   m_LocalRotation: {x: -0.00012399502, y: 0.00052538066, z: 0.00273948, w: 0.9999961}
   m_LocalPosition: {x: -0.11597685, y: 9.7699626e-17, z: 1.7208457e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 845572721}
   m_Father: {fileID: 1517974057}
@@ -25471,6 +26090,7 @@ Transform:
   m_LocalRotation: {x: 0.0033316321, y: -0.0169537, z: -0.0026204463, w: 0.9998473}
   m_LocalPosition: {x: -0.025226552, y: -0.00011562025, z: -0.0023841697}
   m_LocalScale: {x: 1.0000039, y: 1.0000029, z: 1.0000024}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 804863874}
   m_RootOrder: 0
@@ -25502,6 +26122,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1833912637}
   m_RootOrder: 12
@@ -25517,6 +26138,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -25600,6 +26222,7 @@ Transform:
   m_LocalRotation: {x: 0.056542926, y: 0.7048425, z: -0.056542926, w: 0.7048425}
   m_LocalPosition: {x: -0.16301435, y: 9.7699626e-17, z: -4.0733682e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2079845757}
   m_RootOrder: 0
@@ -25630,6 +26253,7 @@ Transform:
   m_LocalRotation: {x: -0.00013146584, y: -0.013670889, z: 0.032817043, w: 0.9993679}
   m_LocalPosition: {x: -0.1459784, y: -4.6629366e-17, z: -2.4528989e-17}
   m_LocalScale: {x: 1.0000007, y: 1.0000002, z: 1.0000007}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 646541003}
   m_Father: {fileID: 708041729}
@@ -25661,6 +26285,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.16287886, y: 0.000000027959265, z: 0.000000003748803}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1594401694}
   m_RootOrder: 0
@@ -25692,6 +26317,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 756076767}
   m_RootOrder: 0
@@ -25707,6 +26333,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -25781,6 +26408,7 @@ Transform:
   m_LocalRotation: {x: 0.15654893, y: 0.97501314, z: -0.017381625, w: 0.15665177}
   m_LocalPosition: {x: -0.09528863, y: 0.084203795, z: 0.08411823}
   m_LocalScale: {x: 1.0000006, y: 1.0000005, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1379732629}
   m_Father: {fileID: 791463027}
@@ -25812,6 +26440,7 @@ Transform:
   m_LocalRotation: {x: -0.009046391, y: 0.021917243, z: 0.025727285, w: 0.9993878}
   m_LocalPosition: {x: -0.015893577, y: -0.0010325513, z: 0.0003781104}
   m_LocalScale: {x: 1.0000015, y: 1.0000017, z: 1.0000015}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2074154455}
   m_Father: {fileID: 602846087}
@@ -25843,6 +26472,7 @@ Transform:
   m_LocalRotation: {x: 0.056542903, y: 0.7048425, z: -0.056542903, w: 0.7048425}
   m_LocalPosition: {x: 0.1630146, y: 0.0000034868867, z: 0.00000009529151}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 336923209}
   m_RootOrder: 0
@@ -25873,6 +26503,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.15067062, y: -0.0078117703, z: 0.000000001284108}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1763601125}
   m_RootOrder: 0
@@ -25903,6 +26534,7 @@ Transform:
   m_LocalRotation: {x: -0.7060321, y: -0.084708445, z: -0.037965525, w: 0.70206964}
   m_LocalPosition: {x: -0.043953944, y: 0.0027083214, z: -0.038982198}
   m_LocalScale: {x: 0.9999999, y: 1.0000012, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2000136710}
   m_Father: {fileID: 2085037210}
@@ -25934,6 +26566,7 @@ Transform:
   m_LocalRotation: {x: -0.111805744, y: 0.13116649, z: 0.20005274, w: 0.964507}
   m_LocalPosition: {x: -0.06575284, y: -0.027835598, z: -0.0022835932}
   m_LocalScale: {x: 1.0000018, y: 1.0000019, z: 1.0000012}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1074267758}
   m_Father: {fileID: 469796802}
@@ -25965,6 +26598,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.09931313, y: -0.009805115, z: -0.0015692547}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1708228324}
   m_RootOrder: 0
@@ -25995,6 +26629,7 @@ Transform:
   m_LocalRotation: {x: -0.12178339, y: -0.20300739, z: 0.30530372, w: 0.92235917}
   m_LocalPosition: {x: -0.18103224, y: 0.08604571, z: -0.04305515}
   m_LocalScale: {x: 1.0000005, y: 1.0000007, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 967294647}
   m_Father: {fileID: 2045781770}
@@ -26026,6 +26661,7 @@ Transform:
   m_LocalRotation: {x: 0.023209697, y: 0.05780235, z: 0.002899465, w: 0.998054}
   m_LocalPosition: {x: -0.023682663, y: -0.00075404777, z: 0.0010983282}
   m_LocalScale: {x: 0.9999988, y: 0.9999991, z: 0.9999992}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 734533613}
   m_Father: {fileID: 1527297970}
@@ -26057,6 +26693,7 @@ Transform:
   m_LocalRotation: {x: 0.43821856, y: -0.22390336, z: -0.16051973, w: 0.8556081}
   m_LocalPosition: {x: -0.026338825, y: 0.02086117, z: -0.0045268396}
   m_LocalScale: {x: 1.0000012, y: 1.0000008, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 401326678}
   m_Father: {fileID: 2006233022}
@@ -26088,6 +26725,7 @@ Transform:
   m_LocalRotation: {x: -0.55629134, y: -0.41471907, z: 0.11797892, w: 0.71037245}
   m_LocalPosition: {x: -0.08505593, y: -1.0880185e-16, z: -1.2434498e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1897293869}
   m_Father: {fileID: 101193674}
@@ -26121,6 +26759,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2023630874}
   m_RootOrder: 0
@@ -26194,6 +26833,7 @@ Transform:
   m_LocalRotation: {x: 0.11624815, y: 0.69947636, z: -0.10604285, w: 0.6971185}
   m_LocalPosition: {x: -0.12236678, y: -0.0013949821, z: 0.04222679}
   m_LocalScale: {x: 1.0000004, y: 1.0000011, z: 1.0000008}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 616376773}
   m_Father: {fileID: 789471901}
@@ -26226,6 +26866,7 @@ Transform:
   m_LocalRotation: {x: -0.47192225, y: 0.5467804, z: 0.45703635, w: 0.51907456}
   m_LocalPosition: {x: 1.2894577, y: -0.16327994, z: -0.01346737}
   m_LocalScale: {x: 1.0000006, y: 1.0000008, z: 1.000001}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 776312978}
   m_Father: {fileID: 791463027}
@@ -26242,6 +26883,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -26316,6 +26958,7 @@ Transform:
   m_LocalRotation: {x: 0.011179984, y: 0.99979585, z: 0.00023534863, w: -0.016828509}
   m_LocalPosition: {x: 0.06031916, y: 0.0020788328, z: 0.07298301}
   m_LocalScale: {x: 1.0000004, y: 1.0000005, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 184698079}
   m_Father: {fileID: 2020641506}
@@ -26347,6 +26990,7 @@ Transform:
   m_LocalRotation: {x: 0.06540314, y: 0, z: 0, w: 0.99785894}
   m_LocalPosition: {x: 0, y: 1.25, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 175330856}
   m_RootOrder: 3
@@ -26377,6 +27021,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -12.08, y: -1, z: 11.05}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 832498756}
   - {fileID: 175330856}
@@ -26410,6 +27055,7 @@ Transform:
   m_LocalRotation: {x: -0.0931137, y: 0.017067054, z: 0.97876835, w: 0.1817996}
   m_LocalPosition: {x: -0.03154395, y: -0.06754832, z: 0.06546028}
   m_LocalScale: {x: 1.000001, y: 1.0000007, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1458144128}
   m_Father: {fileID: 2045781770}
@@ -26441,6 +27087,7 @@ Transform:
   m_LocalRotation: {x: -0.000000008911413, y: 0.99850297, z: -0.05469786, w: -0.00000016267678}
   m_LocalPosition: {x: 0.1, y: 1.3677425, z: 2.6517928}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 175330856}
   m_RootOrder: 4
@@ -26473,6 +27120,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1601534318}
   m_RootOrder: 0
@@ -26546,6 +27194,7 @@ Transform:
   m_LocalRotation: {x: -0.0056373896, y: 0.03380287, z: 0.024109717, w: 0.9991218}
   m_LocalPosition: {x: -0.13228849, y: -1.1324275e-16, z: -1.1268764e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 244148852}
   m_Father: {fileID: 143524504}
@@ -26577,6 +27226,7 @@ Transform:
   m_LocalRotation: {x: -0.009559559, y: 0.011778613, z: -0.014041897, w: 0.9997863}
   m_LocalPosition: {x: -0.017586209, y: 0.0005113313, z: 0.000152205}
   m_LocalScale: {x: 1.0000015, y: 1.0000012, z: 1.0000017}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1826129839}
   m_Father: {fileID: 1441449727}
@@ -26608,6 +27258,7 @@ Transform:
   m_LocalRotation: {x: 0.017483843, y: 0.9998472, z: 0.000000007449441, w: 1.3026479e-10}
   m_LocalPosition: {x: -0.18568392, y: 0.007427308, z: -2.6214969e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2090427599}
   m_Father: {fileID: 223358921}
@@ -26639,6 +27290,7 @@ Transform:
   m_LocalRotation: {x: -0.0776168, y: 0.08485387, z: 0.12320045, w: 0.98569626}
   m_LocalPosition: {x: -0.076792575, y: -0.012626215, z: -0.0062460983}
   m_LocalScale: {x: 1.0000019, y: 1.0000019, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1502384429}
   m_Father: {fileID: 99827840}
@@ -26672,6 +27324,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1121740899}
   m_RootOrder: 0
@@ -26745,6 +27398,7 @@ Transform:
   m_LocalRotation: {x: 0.011196001, y: 0.99993575, z: 0.000012512218, w: 0.0017732558}
   m_LocalPosition: {x: 0.06083579, y: 0.0020787853, z: -0.072552614}
   m_LocalScale: {x: 1, y: 1.0000002, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 393258976}
   m_Father: {fileID: 2020641506}
@@ -26776,6 +27430,7 @@ Transform:
   m_LocalRotation: {x: 0.69785506, y: 0.09374712, z: -0.060807347, w: 0.7074689}
   m_LocalPosition: {x: -0.0554337, y: 0.0017307289, z: -0.09865367}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2046783598}
   m_Father: {fileID: 508696215}
@@ -26808,6 +27463,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1833912637}
   m_RootOrder: 14
@@ -26823,6 +27479,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -26935,6 +27592,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.09931313, y: -0.009805115, z: -0.0015692547}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1209275683}
   m_RootOrder: 0
@@ -26965,6 +27623,7 @@ Transform:
   m_LocalRotation: {x: -0.7059503, y: 0.03399268, z: 0.0064747767, w: 0.7074155}
   m_LocalPosition: {x: -0.022013659, y: 0.0009110151, z: 0.00011725739}
   m_LocalScale: {x: 1.0000029, y: 1.0000014, z: 1.0000017}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 518729703}
   m_RootOrder: 0
@@ -26995,6 +27654,7 @@ Transform:
   m_LocalRotation: {x: -0.038566142, y: -0.0144198695, z: -0.0068944027, w: 0.9991282}
   m_LocalPosition: {x: -0.015886165, y: 0.0000011769014, z: -0.0026419829}
   m_LocalScale: {x: 1.0000015, y: 1.0000019, z: 1.0000019}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1100480776}
   m_Father: {fileID: 1074298935}
@@ -27026,6 +27686,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.14457126, y: -0.0008165151, z: -0.007399066}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 755630654}
   m_RootOrder: 0
@@ -27058,6 +27719,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 820833468}
   m_RootOrder: 0
@@ -27131,6 +27793,7 @@ Transform:
   m_LocalRotation: {x: 0.000003939498, y: 0.0000023927603, z: -0.26428193, w: 0.9644455}
   m_LocalPosition: {x: -0.37866625, y: 0.003828147, z: -0.0037770213}
   m_LocalScale: {x: 0.9999996, y: 0.99999917, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 160400958}
   m_Father: {fileID: 517371545}
@@ -27162,6 +27825,7 @@ Transform:
   m_LocalRotation: {x: 0.000003939498, y: 0.0000023927603, z: -0.26428193, w: 0.9644455}
   m_LocalPosition: {x: -0.37866625, y: 0.003828147, z: -0.0037770213}
   m_LocalScale: {x: 0.9999996, y: 0.99999917, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 87705337}
   m_Father: {fileID: 568071228}
@@ -27193,6 +27857,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.18333411, y: 4.013332e-17, z: -2.5364335e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 968970583}
   m_RootOrder: 0
@@ -27223,6 +27888,7 @@ Transform:
   m_LocalRotation: {x: -0.11370098, y: 0.97812754, z: -0.16029842, w: -0.0681406}
   m_LocalPosition: {x: -0.118646674, y: 0.109952554, z: -0.007276585}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1804635267}
   m_Father: {fileID: 2045781770}
@@ -27255,6 +27921,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 800359998}
   m_RootOrder: 7
@@ -27270,6 +27937,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -27368,6 +28036,7 @@ Transform:
   m_LocalRotation: {x: -0.3895228, y: 0.5901459, z: -0.51284444, w: -0.48681676}
   m_LocalPosition: {x: -0.07073497, y: 3.330669e-17, z: -1.1213252e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 719929682}
   m_RootOrder: 0
@@ -27398,6 +28067,7 @@ Transform:
   m_LocalRotation: {x: 0.99050975, y: 0.13555767, z: -0.022467816, w: -0.0031346574}
   m_LocalPosition: {x: -0.041389998, y: -0.048910234, z: 0.012788884}
   m_LocalScale: {x: 1.0000011, y: 1.0000005, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 619813543}
   m_Father: {fileID: 1171642106}
@@ -27429,6 +28099,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 316884200}
   m_Father: {fileID: 1885322429}
@@ -27465,6 +28136,7 @@ Transform:
   m_LocalRotation: {x: 0.004569878, y: 0.041777767, z: 0.001183233, w: 0.99911577}
   m_LocalPosition: {x: -0.019415826, y: -0.00041664625, z: -0.0007046589}
   m_LocalScale: {x: 1.0000017, y: 1.0000015, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1849153715}
   m_Father: {fileID: 2037545153}
@@ -27496,6 +28168,7 @@ Transform:
   m_LocalRotation: {x: 0.9905085, y: 0.13556996, z: 0.022448432, w: 0.003137485}
   m_LocalPosition: {x: -0.041387863, y: -0.048911706, z: -0.012787029}
   m_LocalScale: {x: 0.9999999, y: 1.0000006, z: 1.0000008}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1461540377}
   m_Father: {fileID: 165006370}
@@ -27527,6 +28200,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1518571170}
   m_Father: {fileID: 2023630874}
@@ -27563,6 +28237,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1192877028}
   m_Father: {fileID: 57266860}
@@ -27600,6 +28275,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1833912637}
   m_RootOrder: 10
@@ -27615,6 +28291,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -27790,6 +28467,7 @@ Transform:
   m_LocalRotation: {x: -0.5071907, y: -0.49270436, z: -0.454019, w: 0.5420949}
   m_LocalPosition: {x: -0.12343654, y: 2.4047247e-17, z: -4.297936e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 951516282}
   m_RootOrder: 0
@@ -27820,6 +28498,7 @@ Transform:
   m_LocalRotation: {x: 0.0016610491, y: -0.08512243, z: 0.0005081766, w: 0.996369}
   m_LocalPosition: {x: -0.16248012, y: -0.0000006606469, z: 0.000001726818}
   m_LocalScale: {x: 1.0000001, y: 0.99999976, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 981654183}
   - {fileID: 1930364061}
@@ -27855,6 +28534,7 @@ Transform:
   m_LocalRotation: {x: 0.003306259, y: 0.044774983, z: -0.02161404, w: 0.9987578}
   m_LocalPosition: {x: -0, y: -7.105427e-17, z: 1.7763568e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 909412337}
   m_Father: {fileID: 1217311753}
@@ -27886,6 +28566,7 @@ Transform:
   m_LocalRotation: {x: 0.003306259, y: 0.044774983, z: -0.02161404, w: 0.9987578}
   m_LocalPosition: {x: -0, y: -7.105427e-17, z: 1.7763568e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 216922736}
   m_Father: {fileID: 1971861339}
@@ -27917,6 +28598,7 @@ Transform:
   m_LocalRotation: {x: 0.81400937, y: -0.09669037, z: -0.3280601, w: 0.4694852}
   m_LocalPosition: {x: -0.024760697, y: 0.01826633, z: 0.01423601}
   m_LocalScale: {x: 1.0000014, y: 1.0000014, z: 1.0000019}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1706158802}
   m_Father: {fileID: 469796802}
@@ -27948,6 +28630,7 @@ Transform:
   m_LocalRotation: {x: 0.0033062587, y: 0.044774964, z: -0.021614037, w: 0.9987578}
   m_LocalPosition: {x: 1.3805066e-32, y: 3.5527136e-17, z: 3.315681e-32}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 520944351}
   m_Father: {fileID: 1886154246}
@@ -27979,6 +28662,7 @@ Transform:
   m_LocalRotation: {x: 0.00012985706, y: -0.0010473065, z: -0.00044055204, w: 0.99999934}
   m_LocalPosition: {x: -0.23377882, y: 0.00001742176, z: -0.000012771544}
   m_LocalScale: {x: 1, y: 1, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1611882741}
   - {fileID: 1200537752}
@@ -28014,6 +28698,7 @@ Transform:
   m_LocalRotation: {x: -0.4967837, y: 0.50319576, z: 0.4967837, w: 0.50319576}
   m_LocalPosition: {x: -0.08766683, y: -0.0003044751, z: 0.00000001784587}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 223358921}
   - {fileID: 984361475}
@@ -28047,6 +28732,7 @@ Transform:
   m_LocalRotation: {x: 0.00012985706, y: -0.0010473065, z: -0.00044055204, w: 0.99999934}
   m_LocalPosition: {x: -0.23377882, y: 0.00001742176, z: -0.000012771544}
   m_LocalScale: {x: 1, y: 1, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 617037369}
   - {fileID: 1398705784}
@@ -28082,6 +28768,7 @@ Transform:
   m_LocalRotation: {x: 0.06540314, y: 0, z: 0, w: 0.99785894}
   m_LocalPosition: {x: 0, y: 1.25, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 337441687}
   m_RootOrder: 3
@@ -28112,6 +28799,7 @@ Transform:
   m_LocalRotation: {x: 0.0000005580623, y: -0.0000024002752, z: -0.26428223, w: 0.9644454}
   m_LocalPosition: {x: -0.3785454, y: 0.0038244387, z: -0.010314554}
   m_LocalScale: {x: 0.9999998, y: 0.9999996, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 175444218}
   m_Father: {fileID: 1129974861}
@@ -28143,6 +28831,7 @@ Transform:
   m_LocalRotation: {x: 0.000003939498, y: 0.0000023927603, z: -0.26428193, w: 0.9644455}
   m_LocalPosition: {x: -0.37866625, y: 0.003828147, z: -0.0037770213}
   m_LocalScale: {x: 0.9999996, y: 0.99999917, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 440571187}
   m_Father: {fileID: 726432428}
@@ -28174,6 +28863,7 @@ Transform:
   m_LocalRotation: {x: -0.09374654, y: 0.6978552, z: 0.70746905, w: 0.060806755}
   m_LocalPosition: {x: -0.05543403, y: 0.0017306843, z: 0.098653734}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1323134540}
   m_Father: {fileID: 782076274}
@@ -28205,6 +28895,7 @@ Transform:
   m_LocalRotation: {x: -0.7153496, y: -0.024095412, z: 0.023904901, w: 0.6979419}
   m_LocalPosition: {x: -0.021249697, y: 0.0010069837, z: 0.0016369896}
   m_LocalScale: {x: 1.0000044, y: 1.0000023, z: 1.0000025}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 965901615}
   m_RootOrder: 0
@@ -28235,6 +28926,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.14476337, y: 0.000000011632276, z: -0.0000000060625056}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1808305624}
   m_RootOrder: 0
@@ -28265,6 +28957,7 @@ Transform:
   m_LocalRotation: {x: -0.00000019811638, y: 0.0008595022, z: 0.99999964, w: 0.0000004702604}
   m_LocalPosition: {x: -0.1029153, y: 1.935459e-17, z: 3.6886607e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1961057263}
   m_RootOrder: 0
@@ -28297,6 +28990,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 57266860}
   m_RootOrder: 3
@@ -28429,6 +29123,7 @@ Transform:
   m_LocalRotation: {x: 0.021434488, y: -0.005929963, z: 0.090837546, w: 0.9956174}
   m_LocalPosition: {x: -0.078083195, y: -0.0055345367, z: -0.0000000015732664}
   m_LocalScale: {x: 1.0000008, y: 1.0000006, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 469448623}
   - {fileID: 1174002155}
@@ -28475,6 +29170,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1833912637}
   m_RootOrder: 11
@@ -28490,6 +29186,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -28603,6 +29300,7 @@ Transform:
   m_LocalRotation: {x: 0.22437504, y: 0.670564, z: -0.50672334, w: -0.4931849}
   m_LocalPosition: {x: -0.14172885, y: -9.7699626e-17, z: -6.7279734e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1826440316}
   m_RootOrder: 0
@@ -28633,6 +29331,7 @@ Transform:
   m_LocalRotation: {x: -0.051157355, y: -0.01140533, z: 0.009748385, w: 0.9985779}
   m_LocalPosition: {x: -0.062838286, y: -0.00004745255, z: -0.0014896186}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 430095238}
   m_RootOrder: 0
@@ -28663,6 +29362,7 @@ Transform:
   m_LocalRotation: {x: -0.70609546, y: -0.036204185, z: -0.035443116, w: 0.7063018}
   m_LocalPosition: {x: -0.044251043, y: 0.00025278676, z: -0.037730616}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 787972422}
   m_Father: {fileID: 1105383886}
@@ -28694,6 +29394,7 @@ Transform:
   m_LocalRotation: {x: 0.22437504, y: 0.670564, z: -0.50672334, w: -0.4931849}
   m_LocalPosition: {x: -0.14172885, y: -9.7699626e-17, z: -6.7279734e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 967294647}
   m_RootOrder: 0
@@ -28724,6 +29425,7 @@ Transform:
   m_LocalRotation: {x: 0.81400937, y: -0.09669037, z: -0.3280601, w: 0.4694852}
   m_LocalPosition: {x: -0.024760697, y: 0.01826633, z: 0.01423601}
   m_LocalScale: {x: 1.0000014, y: 1.0000014, z: 1.0000019}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 830713524}
   m_Father: {fileID: 1410784690}
@@ -28755,6 +29457,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.14476337, y: 0.000000011632276, z: -0.0000000060625056}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1071320562}
   m_RootOrder: 0
@@ -28785,6 +29488,7 @@ Transform:
   m_LocalRotation: {x: -0.0018971404, y: 0.029820867, z: -0.057946537, w: 0.9978724}
   m_LocalPosition: {x: -0.032145437, y: 0.0019859255, z: 0.0015229473}
   m_LocalScale: {x: 0.99999994, y: 1.0000001, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1390862513}
   m_Father: {fileID: 1626421397}
@@ -28816,6 +29520,7 @@ Transform:
   m_LocalRotation: {x: 0.69785506, y: 0.09374712, z: -0.060807347, w: 0.7074689}
   m_LocalPosition: {x: -0.0554337, y: 0.0017307289, z: -0.09865367}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1499654263}
   m_Father: {fileID: 782076274}
@@ -28848,6 +29553,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1958260907}
   - {fileID: 1083473877}
@@ -28952,6 +29658,7 @@ Transform:
   m_LocalRotation: {x: 0.00012215874, y: -0.00051764084, z: 0.0027444, w: 0.9999961}
   m_LocalPosition: {x: -0.11597514, y: 6.217249e-17, z: -2.5535128e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1905692506}
   m_Father: {fileID: 244745790}
@@ -28983,6 +29690,7 @@ Transform:
   m_LocalRotation: {x: -0.04601018, y: 0.9977064, z: 0.038900446, w: -0.03085172}
   m_LocalPosition: {x: -0.118353106, y: 0.11062721, z: -0.0006468265}
   m_LocalScale: {x: 1.0000006, y: 1.0000004, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 471246735}
   m_Father: {fileID: 2045781770}
@@ -29014,6 +29722,7 @@ Transform:
   m_LocalRotation: {x: 0.024370978, y: -0.06598202, z: -0.008131702, w: 0.99749}
   m_LocalPosition: {x: -0.021437468, y: -0.000471134, z: -0.0050665224}
   m_LocalScale: {x: 1.000002, y: 1.000002, z: 1.0000015}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1895185960}
   m_RootOrder: 0
@@ -29046,6 +29755,7 @@ Transform:
   m_LocalRotation: {x: -0.47192204, y: 0.5467805, z: 0.45703653, w: 0.51907444}
   m_LocalPosition: {x: 1.289459, y: -0.16328037, z: -0.013468142}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1220662872}
   m_RootOrder: 3
@@ -29061,6 +29771,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -29125,6 +29836,7 @@ Transform:
   m_LocalRotation: {x: 0.95549077, y: 0.1616498, z: 0.04944903, w: -0.24178815}
   m_LocalPosition: {x: -0.065019004, y: -0.027721604, z: 0.010366318}
   m_LocalScale: {x: 1.0000012, y: 1.0000013, z: 1.000001}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 464757794}
   m_Father: {fileID: 1966244813}
@@ -29156,6 +29868,7 @@ Transform:
   m_LocalRotation: {x: 0.9641222, y: 0.08804348, z: 0.08698386, w: -0.23484161}
   m_LocalPosition: {x: -0.07430402, y: -0.013710743, z: 0.01965605}
   m_LocalScale: {x: 1.0000013, y: 1.0000014, z: 1.0000008}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 820951057}
   m_Father: {fileID: 2006233022}
@@ -29187,6 +29900,7 @@ Transform:
   m_LocalRotation: {x: 0.004569878, y: 0.041777767, z: 0.001183233, w: 0.99911577}
   m_LocalPosition: {x: -0.019415826, y: -0.00041664625, z: -0.0007046589}
   m_LocalScale: {x: 1.0000017, y: 1.0000015, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1780247852}
   m_Father: {fileID: 276446135}
@@ -29218,6 +29932,7 @@ Transform:
   m_LocalRotation: {x: 0.50088733, y: -0.4991111, z: -0.4991111, w: 0.50088733}
   m_LocalPosition: {x: -0, y: 0.86858183, z: 0.011826879}
   m_LocalScale: {x: 0.9999992, y: 0.9999991, z: 0.9999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1237647822}
   - {fileID: 964777226}
@@ -29255,6 +29970,7 @@ Transform:
   m_LocalRotation: {x: -0.518709, y: 0.071315005, z: -0.14153358, w: 0.84013295}
   m_LocalPosition: {x: -0.07073235, y: 5.4780847e-17, z: -8.082631e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1998879210}
   m_RootOrder: 0
@@ -29286,6 +30002,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1311595006}
   m_RootOrder: 11
@@ -29301,6 +30018,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -29414,6 +30132,7 @@ Transform:
   m_LocalRotation: {x: 0.0969805, y: -0.016514864, z: -0.068927996, w: 0.9927593}
   m_LocalPosition: {x: -0.026287906, y: 0.001587632, z: -0.000030333284}
   m_LocalScale: {x: 1.0000021, y: 1.0000017, z: 1.0000019}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2062853382}
   m_RootOrder: 0
@@ -29444,6 +30163,7 @@ Transform:
   m_LocalRotation: {x: 0.70492166, y: 0.054471448, z: -0.05372531, w: 0.70514673}
   m_LocalPosition: {x: -0.044249896, y: 0.00025344297, z: 0.03772974}
   m_LocalScale: {x: 0.9999999, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1482822199}
   m_Father: {fileID: 165006370}
@@ -29475,6 +30195,7 @@ Transform:
   m_LocalRotation: {x: 0.15654893, y: 0.97501314, z: -0.017381625, w: 0.15665177}
   m_LocalPosition: {x: -0.09528863, y: 0.084203795, z: 0.08411823}
   m_LocalScale: {x: 1.0000006, y: 1.0000005, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1246280240}
   m_Father: {fileID: 1220662872}
@@ -29506,6 +30227,7 @@ Transform:
   m_LocalRotation: {x: 0.008649987, y: 0.046947528, z: -0.0062286453, w: 0.9988405}
   m_LocalPosition: {x: -0.07190698, y: -3.593991e-18, z: -4.7696836e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1773661091}
   m_Father: {fileID: 741733952}
@@ -29537,6 +30259,7 @@ Transform:
   m_LocalRotation: {x: 0.08809389, y: 0.23000443, z: 0.29465634, w: 0.92331743}
   m_LocalPosition: {x: -0.17970763, y: 0.08956378, z: 0.041412033}
   m_LocalScale: {x: 1.0000005, y: 1.0000007, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1261318230}
   m_Father: {fileID: 791463027}
@@ -29568,6 +30291,7 @@ Transform:
   m_LocalRotation: {x: -0.518709, y: 0.071315005, z: -0.14153358, w: 0.84013295}
   m_LocalPosition: {x: -0.07073235, y: 5.4780847e-17, z: -8.082631e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1769472536}
   m_RootOrder: 0
@@ -29599,6 +30323,7 @@ Transform:
   m_LocalRotation: {x: -0.47192225, y: 0.5467804, z: 0.45703635, w: 0.51907456}
   m_LocalPosition: {x: 1.2894577, y: -0.16327994, z: -0.01346737}
   m_LocalScale: {x: 1.0000006, y: 1.0000008, z: 1.000001}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1220662872}
   m_RootOrder: 14
@@ -29614,6 +30339,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -29692,6 +30418,7 @@ Transform:
   m_LocalRotation: {x: 0.024370978, y: -0.06598202, z: -0.008131702, w: 0.99749}
   m_LocalPosition: {x: -0.021437468, y: -0.000471134, z: -0.0050665224}
   m_LocalScale: {x: 1.000002, y: 1.000002, z: 1.0000015}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1743498168}
   m_RootOrder: 0
@@ -29722,6 +30449,7 @@ Transform:
   m_LocalRotation: {x: -0.0000059582267, y: -0.00262653, z: -0.0006767927, w: 0.99999636}
   m_LocalPosition: {x: -0.055437315, y: -0.000000047463757, z: -0.0000009960296}
   m_LocalScale: {x: 1, y: 0.9999999, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 165006370}
   m_Father: {fileID: 945400178}
@@ -29753,6 +30481,7 @@ Transform:
   m_LocalRotation: {x: -0.0043129246, y: 0.02031516, z: 0.019814534, w: 0.99958795}
   m_LocalPosition: {x: -0.13655789, y: -2.184919e-15, z: 3.2862602e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1077784555}
   m_Father: {fileID: 1258178865}
@@ -29786,6 +30515,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2023630874}
   m_RootOrder: 4
@@ -29918,6 +30648,7 @@ Transform:
   m_LocalRotation: {x: -0.70609546, y: -0.036204185, z: -0.035443116, w: 0.7063018}
   m_LocalPosition: {x: -0.044251043, y: 0.00025278676, z: -0.037730616}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 977065984}
   m_Father: {fileID: 1171642106}
@@ -29949,6 +30680,7 @@ Transform:
   m_LocalRotation: {x: -0.051157355, y: -0.01140533, z: 0.009748385, w: 0.9985779}
   m_LocalPosition: {x: -0.062838286, y: -0.00004745255, z: -0.0014896186}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1562743016}
   m_RootOrder: 0
@@ -29979,6 +30711,7 @@ Transform:
   m_LocalRotation: {x: -0.7060321, y: -0.084708445, z: -0.037965525, w: 0.70206964}
   m_LocalPosition: {x: -0.043953944, y: 0.0027083214, z: -0.038982198}
   m_LocalScale: {x: 0.9999999, y: 1.0000012, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1656832025}
   m_Father: {fileID: 1649063563}
@@ -30010,6 +30743,7 @@ Transform:
   m_LocalRotation: {x: 0.004313685, y: -0.020318924, z: 0.019809484, w: 0.999588}
   m_LocalPosition: {x: -0.13656151, y: 1.110223e-16, z: -5.5511148e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1816965476}
   m_Father: {fileID: 866934120}
@@ -30041,6 +30775,7 @@ Transform:
   m_LocalRotation: {x: -0.000108155284, y: 0.0073531894, z: -0.058960136, w: 0.99823326}
   m_LocalPosition: {x: -1.4210854e-16, y: -3.5527136e-17, z: -1.7763568e-17}
   m_LocalScale: {x: 0.99999946, y: 0.99999946, z: 0.99999964}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 245061511}
   m_Father: {fileID: 1329599035}
@@ -30072,6 +30807,7 @@ Transform:
   m_LocalRotation: {x: -0.038566142, y: -0.0144198695, z: -0.0068944027, w: 0.9991282}
   m_LocalPosition: {x: -0.015886165, y: 0.0000011769014, z: -0.0026419829}
   m_LocalScale: {x: 1.0000015, y: 1.0000019, z: 1.0000019}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 21738753}
   m_Father: {fileID: 731264708}
@@ -30103,6 +30839,7 @@ Transform:
   m_LocalRotation: {x: -0.0056373896, y: 0.03380287, z: 0.024109717, w: 0.9991218}
   m_LocalPosition: {x: -0.13228849, y: -1.1324275e-16, z: -1.1268764e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 406074854}
   m_Father: {fileID: 1811189548}
@@ -30136,6 +30873,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 257494603}
   m_RootOrder: 0
@@ -30209,6 +30947,7 @@ Transform:
   m_LocalRotation: {x: 0.024406396, y: -0.040521923, z: -0.013085931, w: 0.99879485}
   m_LocalPosition: {x: -0.018097645, y: -0.00014428438, z: -0.00005280069}
   m_LocalScale: {x: 1.0000018, y: 1.0000017, z: 1.0000018}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 490431110}
   m_Father: {fileID: 2068880792}
@@ -30240,6 +30979,7 @@ Transform:
   m_LocalRotation: {x: 0.0969805, y: -0.016514864, z: -0.068927996, w: 0.9927593}
   m_LocalPosition: {x: -0.026287906, y: 0.001587632, z: -0.000030333284}
   m_LocalScale: {x: 1.0000021, y: 1.0000017, z: 1.0000019}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1524767899}
   m_RootOrder: 0
@@ -30270,6 +31010,7 @@ Transform:
   m_LocalRotation: {x: -0.55629134, y: -0.41471907, z: 0.11797892, w: 0.71037245}
   m_LocalPosition: {x: -0.08505593, y: -1.0880185e-16, z: -1.2434498e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1678288792}
   m_Father: {fileID: 1431176661}
@@ -30301,6 +31042,7 @@ Transform:
   m_LocalRotation: {x: -0.016843833, y: 0.0388019, z: -0.011487531, w: 0.99903893}
   m_LocalPosition: {x: -0.025354914, y: -0.0006798064, z: 0.0011694904}
   m_LocalScale: {x: 1, y: 0.9999999, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1211573431}
   m_Father: {fileID: 1084053219}
@@ -30332,6 +31074,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 783570941}
   - {fileID: 968805004}
@@ -30378,6 +31121,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 774205173}
   m_RootOrder: 11
@@ -30393,6 +31137,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -30506,6 +31251,7 @@ Transform:
   m_LocalRotation: {x: -0.051588498, y: 0.5376023, z: -0.03311316, w: 0.84096724}
   m_LocalPosition: {x: -0.029250145, y: 0.026847687, z: 0.0006188383}
   m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1846565071}
   m_Father: {fileID: 9718540}
@@ -30537,6 +31283,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.18333384, y: 0.00000003325184, z: 0.00000005255228}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 772533888}
   m_RootOrder: 0
@@ -30568,6 +31315,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 800359998}
   m_RootOrder: 13
@@ -30583,6 +31331,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -30695,6 +31444,7 @@ Transform:
   m_LocalRotation: {x: 0.017483843, y: 0.9998472, z: 0.000000007449441, w: 1.3026479e-10}
   m_LocalPosition: {x: -0.18568392, y: 0.007427308, z: -2.6214969e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 278446267}
   m_Father: {fileID: 1836277122}
@@ -30726,6 +31476,7 @@ Transform:
   m_LocalRotation: {x: 0.024370978, y: -0.06598202, z: -0.008131702, w: 0.99749}
   m_LocalPosition: {x: -0.021437468, y: -0.000471134, z: -0.0050665224}
   m_LocalScale: {x: 1.000002, y: 1.000002, z: 1.0000015}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1583154628}
   m_RootOrder: 0
@@ -30756,6 +31507,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.15477863, y: 6.883383e-17, z: 1.2212453e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2088554363}
   m_RootOrder: 0
@@ -30788,6 +31540,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1709218426}
   m_RootOrder: 3
@@ -30920,6 +31673,7 @@ Transform:
   m_LocalRotation: {x: 0.08809389, y: 0.23000443, z: 0.29465634, w: 0.92331743}
   m_LocalPosition: {x: -0.17970763, y: 0.08956378, z: 0.041412033}
   m_LocalScale: {x: 1.0000005, y: 1.0000007, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2119275144}
   m_Father: {fileID: 1220662872}
@@ -30951,6 +31705,7 @@ Transform:
   m_LocalRotation: {x: 0.06540314, y: 0, z: 0, w: 0.99785894}
   m_LocalPosition: {x: 0, y: 1.25, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1912998594}
   m_RootOrder: 3
@@ -30981,6 +31736,7 @@ Transform:
   m_LocalRotation: {x: -0.73015964, y: 0, z: 0, w: 0.6832766}
   m_LocalPosition: {x: -0.14825143, y: -0.010895066, z: 0.018342203}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2035742064}
   m_RootOrder: 0
@@ -31012,6 +31768,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1311595006}
   m_RootOrder: 14
@@ -31027,6 +31784,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -31139,6 +31897,7 @@ Transform:
   m_LocalRotation: {x: 0.95549077, y: 0.1616498, z: 0.04944903, w: -0.24178815}
   m_LocalPosition: {x: -0.065019004, y: -0.027721604, z: 0.010366318}
   m_LocalScale: {x: 1.0000012, y: 1.0000013, z: 1.000001}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1025002729}
   m_Father: {fileID: 2006233022}
@@ -31170,6 +31929,7 @@ Transform:
   m_LocalRotation: {x: 0.858846, y: 0.1550803, z: -0.007265332, w: -0.4881402}
   m_LocalPosition: {x: -0.14172979, y: -4.4408918e-17, z: 2.8865798e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1261318230}
   m_RootOrder: 0
@@ -31201,6 +31961,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 795481671}
   - {fileID: 1121740899}
@@ -31304,6 +32065,7 @@ Transform:
   m_LocalRotation: {x: -0.0043129246, y: 0.02031516, z: 0.019814534, w: 0.99958795}
   m_LocalPosition: {x: -0.13655789, y: -2.184919e-15, z: 3.2862602e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 706218996}
   m_Father: {fileID: 49639835}
@@ -31335,6 +32097,7 @@ Transform:
   m_LocalRotation: {x: -0.054846227, y: 0.006185361, z: 0.99130034, w: 0.11948777}
   m_LocalPosition: {x: -0.072350614, y: -0.041271094, z: 0.05315229}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 511649317}
   - {fileID: 1633130421}
@@ -31367,6 +32130,7 @@ Transform:
   m_LocalRotation: {x: -0.7060321, y: -0.084708445, z: -0.037965525, w: 0.70206964}
   m_LocalPosition: {x: -0.043953944, y: 0.0027083214, z: -0.038982198}
   m_LocalScale: {x: 0.9999999, y: 1.0000012, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1181258586}
   m_Father: {fileID: 165006370}
@@ -31398,6 +32162,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.15477823, y: 7.5495166e-17, z: -6.383782e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2124865943}
   m_RootOrder: 0
@@ -31428,6 +32193,7 @@ Transform:
   m_LocalRotation: {x: -0.008016839, y: 0.09734642, z: 0.058641255, w: 0.99348915}
   m_LocalPosition: {x: -0.13752584, y: 1.1990408e-16, z: -3.1086245e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 354467952}
   m_Father: {fileID: 1267371240}
@@ -31461,6 +32227,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1424463373}
   m_RootOrder: 0
@@ -31534,6 +32301,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 695296141}
   m_Father: {fileID: 231704635}
@@ -31570,6 +32338,7 @@ Transform:
   m_LocalRotation: {x: 0.004569878, y: 0.041777767, z: 0.001183233, w: 0.99911577}
   m_LocalPosition: {x: -0.019415826, y: -0.00041664625, z: -0.0007046589}
   m_LocalScale: {x: 1.0000017, y: 1.0000015, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1732378816}
   m_Father: {fileID: 210577459}
@@ -31603,6 +32372,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 57266860}
   m_RootOrder: 0
@@ -31676,6 +32446,7 @@ Transform:
   m_LocalRotation: {x: 0.22437504, y: 0.670564, z: -0.50672334, w: -0.4931849}
   m_LocalPosition: {x: -0.14172885, y: -9.7699626e-17, z: -6.7279734e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1507844007}
   m_RootOrder: 0
@@ -31706,6 +32477,7 @@ Transform:
   m_LocalRotation: {x: 0.002749186, y: -0.061828945, z: 0.0046093785, w: 0.9980723}
   m_LocalPosition: {x: -0.016096681, y: 0.000118210985, z: -0.00045832127}
   m_LocalScale: {x: 1.0000032, y: 1.0000025, z: 1.000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1907725345}
   m_Father: {fileID: 1245057946}
@@ -31737,6 +32509,7 @@ Transform:
   m_LocalRotation: {x: 0.012592068, y: -0.04324944, z: -0.00322445, w: 0.99897975}
   m_LocalPosition: {x: -0.025126116, y: -0.00003483637, z: -0.0032739432}
   m_LocalScale: {x: 1.000002, y: 1.0000018, z: 1.0000014}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2108850526}
   m_RootOrder: 0
@@ -31767,6 +32540,7 @@ Transform:
   m_LocalRotation: {x: 0.004313685, y: -0.020318924, z: 0.019809484, w: 0.999588}
   m_LocalPosition: {x: -0.13656151, y: 1.110223e-16, z: -5.5511148e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1267371240}
   m_Father: {fileID: 1723316244}
@@ -31798,6 +32572,7 @@ Transform:
   m_LocalRotation: {x: -0.7153496, y: -0.024095412, z: 0.023904901, w: 0.6979419}
   m_LocalPosition: {x: -0.021249697, y: 0.0010069837, z: 0.0016369896}
   m_LocalScale: {x: 1.0000044, y: 1.0000023, z: 1.0000025}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1900531318}
   m_RootOrder: 0
@@ -31830,6 +32605,7 @@ Transform:
   m_LocalRotation: {x: -0.47192204, y: 0.5467805, z: 0.45703653, w: 0.51907444}
   m_LocalPosition: {x: 1.289459, y: -0.16328037, z: -0.013468142}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1665962212}
   m_RootOrder: 4
@@ -31845,6 +32621,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -31909,6 +32686,7 @@ Transform:
   m_LocalRotation: {x: 0.023209697, y: 0.05780235, z: 0.002899465, w: 0.998054}
   m_LocalPosition: {x: -0.023682663, y: -0.00075404777, z: 0.0010983282}
   m_LocalScale: {x: 0.9999988, y: 0.9999991, z: 0.9999992}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2005841854}
   m_Father: {fileID: 2101486621}
@@ -31965,13 +32743,14 @@ MonoBehaviour:
   TransitionSetting:
     OutputTargetWeight: 1
     FadeInTime: 0.2
+    FixedTimeOffset: 0
     ExitTime: 0
     ClipSpeed: 1
     RestartWhenPlay: 1
   ToClip: {fileID: 7400000, guid: 26055e26f15260e4e8e0e51f50c41926, type: 3}
 --- !u!95 &1912998593
 Animator:
-  serializedVersion: 3
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -31984,10 +32763,12 @@ Animator:
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!4 &1912998594
 Transform:
   m_ObjectHideFlags: 0
@@ -31998,6 +32779,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: 3, y: 0, z: 3}
   m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 748756605}
   - {fileID: 1208126355}
@@ -32034,6 +32816,7 @@ Transform:
   m_LocalRotation: {x: 0.84096724, y: 0.03311328, z: 0.5376023, w: 0.05158868}
   m_LocalPosition: {x: 0.029250061, y: 0.02684879, z: 0.0006188783}
   m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1229604190}
   m_Father: {fileID: 9718540}
@@ -32065,6 +32848,7 @@ Transform:
   m_LocalRotation: {x: 0.023209697, y: 0.05780235, z: 0.002899465, w: 0.998054}
   m_LocalPosition: {x: -0.023682663, y: -0.00075404777, z: 0.0010983282}
   m_LocalScale: {x: 0.9999988, y: 0.9999991, z: 0.9999992}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 804863874}
   m_Father: {fileID: 168661893}
@@ -32096,6 +32880,7 @@ Transform:
   m_LocalRotation: {x: 0.018954959, y: -0.016845439, z: 0.022771137, w: 0.99941903}
   m_LocalPosition: {x: -0.01809678, y: 0.00013280302, z: -0.000014452478}
   m_LocalScale: {x: 1.0000025, y: 1.0000023, z: 1.0000019}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 796320436}
   m_Father: {fileID: 771405006}
@@ -32127,6 +32912,7 @@ Transform:
   m_LocalRotation: {x: 0.0221195, y: 0.9987083, z: 0.0010128983, w: 0.045732945}
   m_LocalPosition: {x: -0.068878286, y: 0.07501759, z: 0.056856666}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 23038245}
   - {fileID: 1284497236}
@@ -32161,6 +32947,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 231704635}
   m_RootOrder: 3
@@ -32293,6 +33080,7 @@ Transform:
   m_LocalRotation: {x: 0.9944477, y: 0.028325185, z: -0.06578186, w: -0.077098854}
   m_LocalPosition: {x: -0.07734096, y: 0.004360036, z: 0.024110846}
   m_LocalScale: {x: 1.0000012, y: 1.0000014, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 276446135}
   m_Father: {fileID: 1611882741}
@@ -32324,6 +33112,7 @@ Transform:
   m_LocalRotation: {x: 0.08809389, y: 0.23000443, z: 0.29465634, w: 0.92331743}
   m_LocalPosition: {x: -0.17970763, y: 0.08956378, z: 0.041412033}
   m_LocalScale: {x: 1.0000005, y: 1.0000007, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1203742626}
   m_Father: {fileID: 2045781770}
@@ -32358,6 +33147,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 549404819}
   m_Father: {fileID: 991802154}
@@ -32501,6 +33291,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1311595006}
   m_RootOrder: 3
@@ -32516,6 +33307,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -32599,6 +33391,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1833912637}
   m_RootOrder: 7
@@ -32614,6 +33407,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -32712,6 +33506,7 @@ Transform:
   m_LocalRotation: {x: 0.00013144138, y: 0.013670122, z: 0.032817103, w: 0.9993679}
   m_LocalPosition: {x: -0.14597888, y: 2.1649348e-17, z: 2.7131074e-17}
   m_LocalScale: {x: 1.0000007, y: 1.0000002, z: 1.0000007}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1167920104}
   m_Father: {fileID: 244148852}
@@ -32743,6 +33538,7 @@ Transform:
   m_LocalRotation: {x: 0.11624815, y: 0.69947636, z: -0.10604285, w: 0.6971185}
   m_LocalPosition: {x: -0.12236678, y: -0.0013949821, z: 0.04222679}
   m_LocalScale: {x: 1.0000004, y: 1.0000011, z: 1.0000008}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 243604037}
   m_Father: {fileID: 373212390}
@@ -32775,6 +33571,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1833912637}
   m_RootOrder: 6
@@ -32790,6 +33587,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -32909,6 +33707,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1709218426}
   m_RootOrder: 0
@@ -32982,6 +33781,7 @@ Transform:
   m_LocalRotation: {x: -0.002221635, y: -0.033948217, z: 0.021046568, w: 0.9991995}
   m_LocalPosition: {x: -0.14191027, y: 3.7508402e-17, z: 3.2530684e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1657926553}
   m_Father: {fileID: 1368825472}
@@ -33013,6 +33813,7 @@ Transform:
   m_LocalRotation: {x: 0.0016610491, y: -0.08512243, z: 0.0005081766, w: 0.996369}
   m_LocalPosition: {x: -0.16248012, y: -0.0000006606469, z: 0.000001726818}
   m_LocalScale: {x: 1.0000001, y: 0.99999976, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2032648716}
   - {fileID: 67204865}
@@ -33048,6 +33849,7 @@ Transform:
   m_LocalRotation: {x: 0.018954959, y: -0.016845439, z: 0.022771137, w: 0.99941903}
   m_LocalPosition: {x: -0.01809678, y: 0.00013280302, z: -0.000014452478}
   m_LocalScale: {x: 1.0000025, y: 1.0000023, z: 1.0000019}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 262308063}
   m_Father: {fileID: 928223173}
@@ -33079,6 +33881,7 @@ Transform:
   m_LocalRotation: {x: 0.0066097225, y: 0.051325165, z: -0.11946504, w: 0.9914889}
   m_LocalPosition: {x: -0.071971275, y: -0.041271117, z: -0.05366487}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2068976104}
   - {fileID: 1613615407}
@@ -33111,6 +33914,7 @@ Transform:
   m_LocalRotation: {x: 0.99050975, y: 0.13555767, z: -0.022467816, w: -0.0031346574}
   m_LocalPosition: {x: -0.041389998, y: -0.048910234, z: 0.012788884}
   m_LocalScale: {x: 1.0000011, y: 1.0000005, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 516929081}
   m_Father: {fileID: 1105383886}
@@ -33142,6 +33946,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.18333384, y: 0.00000003325184, z: 0.00000005255228}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 307125089}
   m_RootOrder: 0
@@ -33172,6 +33977,7 @@ Transform:
   m_LocalRotation: {x: 0.000005962055, y: 0.0026267671, z: -0.000676907, w: 0.99999636}
   m_LocalPosition: {x: -0.055436894, y: -0.000000047903697, z: 0.00000091983424}
   m_LocalScale: {x: 0.9999999, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1030197144}
   m_Father: {fileID: 86567734}
@@ -33203,6 +34009,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.1628788, y: -0.0000000020954543, z: 0.0000000016000674}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 973113845}
   m_RootOrder: 0
@@ -33233,6 +34040,7 @@ Transform:
   m_LocalRotation: {x: -0.0478358, y: -0.0038424567, z: 0.0030543627, w: 0.9988432}
   m_LocalPosition: {x: -0.01920933, y: -0.00029923706, z: -0.00002337768}
   m_LocalScale: {x: 1.0000054, y: 1.0000043, z: 1.0000037}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2143572289}
   m_RootOrder: 0
@@ -33265,6 +34073,7 @@ Transform:
   m_LocalRotation: {x: -0.47192204, y: 0.5467805, z: 0.45703653, w: 0.51907444}
   m_LocalPosition: {x: 1.289459, y: -0.16328037, z: -0.013468142}
   m_LocalScale: {x: 1.0000004, y: 1.0000006, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 791463027}
   m_RootOrder: 4
@@ -33280,6 +34089,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -33344,6 +34154,7 @@ Transform:
   m_LocalRotation: {x: 0.008649987, y: 0.046947528, z: -0.0062286453, w: 0.9988405}
   m_LocalPosition: {x: -0.07190698, y: -3.593991e-18, z: -4.7696836e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1756283989}
   m_Father: {fileID: 452507464}
@@ -33375,6 +34186,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.14476337, y: 0.000000011632276, z: -0.0000000060625056}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1496334694}
   m_RootOrder: 0
@@ -33405,6 +34217,7 @@ Transform:
   m_LocalRotation: {x: 0.70492166, y: 0.054471448, z: -0.05372531, w: 0.70514673}
   m_LocalPosition: {x: -0.044249896, y: 0.00025344297, z: 0.03772974}
   m_LocalScale: {x: 0.9999999, y: 1.0000006, z: 1.0000004}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 773598291}
   m_Father: {fileID: 2085037210}
@@ -33436,6 +34249,7 @@ Transform:
   m_LocalRotation: {x: -0.028132368, y: -0.03407927, z: -0.0024114775, w: 0.9990202}
   m_LocalPosition: {x: -0.015907401, y: 0.00016659354, z: -0.00086091814}
   m_LocalScale: {x: 1.0000031, y: 1.0000023, z: 1.000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 641879603}
   m_Father: {fileID: 1910767879}
@@ -33467,6 +34281,7 @@ Transform:
   m_LocalRotation: {x: 0.0016610491, y: -0.08512243, z: 0.0005081766, w: 0.996369}
   m_LocalPosition: {x: -0.16248012, y: -0.0000006606469, z: 0.000001726818}
   m_LocalScale: {x: 1.0000001, y: 0.99999976, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 100610769}
   - {fileID: 564780876}
@@ -33503,6 +34318,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 800359998}
   m_RootOrder: 0
@@ -33518,6 +34334,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -33599,6 +34416,7 @@ Transform:
   m_LocalRotation: {x: 0.056542903, y: 0.7048425, z: -0.056542903, w: 0.7048425}
   m_LocalPosition: {x: 0.1630146, y: 0.0000034868867, z: 0.00000009529151}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 95811608}
   m_RootOrder: 0
@@ -33629,6 +34447,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2020641506}
   m_Father: {fileID: 175330856}
@@ -33660,6 +34479,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.14900754, y: -0.013332438, z: 0.007244749}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1200537752}
   m_RootOrder: 0
@@ -33690,6 +34510,7 @@ Transform:
   m_LocalRotation: {x: 0.00047884785, y: 0.014813263, z: 0.03715169, w: 0.99919975}
   m_LocalPosition: {x: -0.017565973, y: -0.0010033782, z: 0.000084740605}
   m_LocalScale: {x: 1.0000027, y: 1.0000021, z: 1.0000026}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 535210296}
   m_Father: {fileID: 915671414}
@@ -33722,6 +34543,7 @@ Transform:
   m_LocalRotation: {x: -0.47192225, y: 0.5467804, z: 0.45703635, w: 0.51907456}
   m_LocalPosition: {x: 1.2894577, y: -0.16327994, z: -0.01346737}
   m_LocalScale: {x: 1.0000006, y: 1.0000008, z: 1.000001}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1665962212}
   m_RootOrder: 14
@@ -33737,6 +34559,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -33815,6 +34638,7 @@ Transform:
   m_LocalRotation: {x: -0.7059503, y: 0.03399268, z: 0.0064747767, w: 0.7074155}
   m_LocalPosition: {x: -0.022013659, y: 0.0009110151, z: 0.00011725739}
   m_LocalScale: {x: 1.0000029, y: 1.0000014, z: 1.0000017}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1337186577}
   m_RootOrder: 0
@@ -33845,6 +34669,7 @@ Transform:
   m_LocalRotation: {x: 0.50088733, y: -0.4991111, z: -0.4991111, w: 0.50088733}
   m_LocalPosition: {x: -0, y: 0.86858183, z: 0.011826879}
   m_LocalScale: {x: 0.9999992, y: 0.9999991, z: 0.9999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1511192738}
   - {fileID: 1531712338}
@@ -33882,6 +34707,7 @@ Transform:
   m_LocalRotation: {x: 0.0033062587, y: 0.044774964, z: -0.021614037, w: 0.9987578}
   m_LocalPosition: {x: 1.3805066e-32, y: 3.5527136e-17, z: 3.315681e-32}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 638467204}
   m_Father: {fileID: 481277443}
@@ -33914,6 +34740,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1508286439}
   - {fileID: 476798957}
@@ -34017,6 +34844,7 @@ Transform:
   m_LocalRotation: {x: -0.55629134, y: -0.41471907, z: 0.11797892, w: 0.71037245}
   m_LocalPosition: {x: -0.08505593, y: -1.0880185e-16, z: -1.2434498e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 296175016}
   m_Father: {fileID: 290858058}
@@ -34048,6 +34876,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.049171697, w: 0.9987904}
   m_LocalPosition: {x: -0.09134354, y: 0.0017551515, z: -0.000000006891526}
   m_LocalScale: {x: 1.0000002, y: 1.0000002, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 675793193}
   - {fileID: 1648083170}
@@ -34080,6 +34909,7 @@ Transform:
   m_LocalRotation: {x: 0.000003939498, y: 0.0000023927603, z: -0.26428193, w: 0.9644455}
   m_LocalPosition: {x: -0.37866625, y: 0.003828147, z: -0.0037770213}
   m_LocalScale: {x: 0.9999996, y: 0.99999917, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 795442344}
   m_Father: {fileID: 184698079}
@@ -34111,6 +34941,7 @@ Transform:
   m_LocalRotation: {x: 0.99590546, y: -0.01934041, z: -0.041608024, w: -0.07789138}
   m_LocalPosition: {x: -0.07745903, y: 0.024773534, z: 0.02387737}
   m_LocalScale: {x: 1.0000012, y: 1.0000013, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1074298935}
   m_Father: {fileID: 1966244813}
@@ -34142,6 +34973,7 @@ Transform:
   m_LocalRotation: {x: -0.06448094, y: -0.087481044, z: -0.08295049, w: 0.9906102}
   m_LocalPosition: {x: -0.047045223, y: 0.036010325, z: 0.0010294426}
   m_LocalScale: {x: 1.0000006, y: 1.0000006, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1875347011}
   m_Father: {fileID: 1105383886}
@@ -34173,6 +35005,7 @@ Transform:
   m_LocalRotation: {x: -0.016843833, y: 0.0388019, z: -0.011487531, w: 0.99903893}
   m_LocalPosition: {x: -0.025354914, y: -0.0006798064, z: 0.0011694904}
   m_LocalScale: {x: 1, y: 0.9999999, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1583154628}
   m_Father: {fileID: 67204865}
@@ -34204,6 +35037,7 @@ Transform:
   m_LocalRotation: {x: 0.007178454, y: 0.0018399023, z: -0.17932878, w: 0.9837613}
   m_LocalPosition: {x: -0.1568513, y: 0.008298479, z: 0.00028669508}
   m_LocalScale: {x: 1.0000005, y: 1.0000008, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 791463027}
   m_Father: {fileID: 1009839551}
@@ -34235,6 +35069,7 @@ Transform:
   m_LocalRotation: {x: 0.021434488, y: -0.005929963, z: 0.090837546, w: 0.9956174}
   m_LocalPosition: {x: -0.078083195, y: -0.0055345367, z: -0.0000000015732664}
   m_LocalScale: {x: 1.0000008, y: 1.0000006, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 966248408}
   - {fileID: 903156252}
@@ -34280,6 +35115,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.09931313, y: -0.009805115, z: -0.0015692547}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1534568254}
   m_RootOrder: 0
@@ -34310,6 +35146,7 @@ Transform:
   m_LocalRotation: {x: -0.04601018, y: 0.9977064, z: 0.038900446, w: -0.03085172}
   m_LocalPosition: {x: -0.118353106, y: 0.11062721, z: -0.0006468265}
   m_LocalScale: {x: 1.0000006, y: 1.0000004, z: 1.0000006}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 646993200}
   m_Father: {fileID: 1665962212}
@@ -34341,6 +35178,7 @@ Transform:
   m_LocalRotation: {x: 0.023209697, y: 0.05780235, z: 0.002899465, w: 0.998054}
   m_LocalPosition: {x: -0.023682663, y: -0.00075404777, z: 0.0010983282}
   m_LocalScale: {x: 0.9999988, y: 0.9999991, z: 0.9999992}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5273866}
   m_Father: {fileID: 417529945}
@@ -34372,6 +35210,7 @@ Transform:
   m_LocalRotation: {x: -0.009559559, y: 0.011778613, z: -0.014041897, w: 0.9997863}
   m_LocalPosition: {x: -0.017586209, y: 0.0005113313, z: 0.000152205}
   m_LocalScale: {x: 1.0000015, y: 1.0000012, z: 1.0000017}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1760327201}
   m_Father: {fileID: 990053586}
@@ -34405,6 +35244,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 4, y: 4, z: 4}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 925209235}
   m_RootOrder: 0
@@ -34482,6 +35322,7 @@ Transform:
   m_LocalRotation: {x: 0.008016311, y: -0.09734142, z: 0.058641404, w: 0.9934896}
   m_LocalPosition: {x: -0.13752587, y: -4.6629366e-17, z: -6.106227e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 335870932}
   m_Father: {fileID: 785855631}
@@ -34513,6 +35354,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -3.0800004, y: -1, z: 11.05}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 498196218}
   - {fileID: 1912998594}
@@ -34546,6 +35388,7 @@ Transform:
   m_LocalRotation: {x: 0.95549077, y: 0.1616498, z: 0.04944903, w: -0.24178815}
   m_LocalPosition: {x: -0.065019004, y: -0.027721604, z: 0.010366318}
   m_LocalScale: {x: 1.0000012, y: 1.0000013, z: 1.000001}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1824010197}
   m_Father: {fileID: 1611882741}
@@ -34577,6 +35420,7 @@ Transform:
   m_LocalRotation: {x: 0.005350928, y: -0.061189618, z: 0.12227407, w: 0.9905939}
   m_LocalPosition: {x: 0.14993037, y: -0.000000002250124, z: -0.000000010045328}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 234062742}
   m_Father: {fileID: 1971861339}
@@ -34608,6 +35452,7 @@ Transform:
   m_LocalRotation: {x: -0.00000019811638, y: 0.0008595022, z: 0.99999964, w: 0.0000004702604}
   m_LocalPosition: {x: -0.1029153, y: 1.935459e-17, z: 3.6886607e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 599455052}
   m_RootOrder: 0
@@ -34639,6 +35484,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1311595006}
   m_RootOrder: 2
@@ -34654,6 +35500,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -34735,6 +35582,7 @@ Transform:
   m_LocalRotation: {x: 0.012592068, y: -0.04324944, z: -0.00322445, w: 0.99897975}
   m_LocalPosition: {x: -0.025126116, y: -0.00003483637, z: -0.0032739432}
   m_LocalScale: {x: 1.000002, y: 1.0000018, z: 1.0000014}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1474463604}
   m_RootOrder: 0
@@ -34765,6 +35613,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.09931355, y: 0.009804863, z: 0.0015692349}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 231517898}
   m_RootOrder: 0
@@ -34796,6 +35645,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 774205173}
   m_RootOrder: 13
@@ -34811,6 +35661,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -34923,6 +35774,7 @@ Transform:
   m_LocalRotation: {x: 0.017483843, y: 0.9998472, z: 0.000000007449441, w: 1.3026479e-10}
   m_LocalPosition: {x: -0.18568392, y: 0.007427308, z: -2.6214969e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1461421321}
   m_Father: {fileID: 171290356}
@@ -34954,6 +35806,7 @@ Transform:
   m_LocalRotation: {x: 0.00012985706, y: -0.0010473065, z: -0.00044055204, w: 0.99999934}
   m_LocalPosition: {x: -0.23377882, y: 0.00001742176, z: -0.000012771544}
   m_LocalScale: {x: 1, y: 1, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1966244813}
   - {fileID: 702050730}
@@ -34989,6 +35842,7 @@ Transform:
   m_LocalRotation: {x: -0.00013146584, y: -0.013670889, z: 0.032817043, w: 0.9993679}
   m_LocalPosition: {x: -0.1459784, y: -4.6629366e-17, z: -2.4528989e-17}
   m_LocalScale: {x: 1.0000007, y: 1.0000002, z: 1.0000007}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1862063580}
   m_Father: {fileID: 121585296}
@@ -35020,6 +35874,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.16287886, y: 0.000000027959265, z: 0.000000003748803}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 193913196}
   m_RootOrder: 0
@@ -35050,6 +35905,7 @@ Transform:
   m_LocalRotation: {x: 0.056542926, y: 0.7048425, z: -0.056542926, w: 0.7048425}
   m_LocalPosition: {x: -0.16301435, y: 9.7699626e-17, z: -4.0733682e-18}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1526159852}
   m_RootOrder: 0
@@ -35083,6 +35939,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 718894265}
   m_Father: {fileID: 1008299214}
@@ -35225,6 +36082,7 @@ Transform:
   m_LocalRotation: {x: -0.0776168, y: 0.08485387, z: 0.12320045, w: 0.98569626}
   m_LocalPosition: {x: -0.076792575, y: -0.012626215, z: -0.0062460983}
   m_LocalScale: {x: 1.0000019, y: 1.0000019, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1910767879}
   m_Father: {fileID: 469796802}
@@ -35257,6 +36115,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1311595006}
   m_RootOrder: 6
@@ -35272,6 +36131,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -35389,6 +36249,7 @@ Transform:
   m_LocalRotation: {x: 0.057060625, y: -0.015512465, z: 0.05145035, w: 0.99692345}
   m_LocalPosition: {x: -0.08069598, y: 0.0058216397, z: -0.0060212403}
   m_LocalScale: {x: 1.0000017, y: 1.0000018, z: 1.0000013}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 556119843}
   m_Father: {fileID: 486394366}
@@ -35420,6 +36281,7 @@ Transform:
   m_LocalRotation: {x: -0.0000073946076, y: -0.0000015158422, z: 0.016451556, w: 0.9998647}
   m_LocalPosition: {x: -0.35136372, y: -0.0080112815, z: -0.018233713}
   m_LocalScale: {x: 1.0000002, y: 1.0000002, z: 1.0000002}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 67590302}
   m_Father: {fileID: 422411307}
@@ -35451,6 +36313,7 @@ Transform:
   m_LocalRotation: {x: -0.009046391, y: 0.021917243, z: 0.025727285, w: 0.9993878}
   m_LocalPosition: {x: -0.015893577, y: -0.0010325513, z: 0.0003781104}
   m_LocalScale: {x: 1.0000015, y: 1.0000017, z: 1.0000015}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1903419063}
   m_Father: {fileID: 820951057}
@@ -35482,6 +36345,7 @@ Transform:
   m_LocalRotation: {x: -0.0931137, y: 0.017067054, z: 0.97876835, w: 0.1817996}
   m_LocalPosition: {x: -0.03154395, y: -0.06754832, z: 0.06546028}
   m_LocalScale: {x: 1.000001, y: 1.0000007, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 972793718}
   m_Father: {fileID: 1220662872}
@@ -35514,6 +36378,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1311595006}
   m_RootOrder: 5
@@ -35529,6 +36394,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -35609,6 +36475,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 774205173}
   m_RootOrder: 4
@@ -35624,6 +36491,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -35710,6 +36578,7 @@ Transform:
   m_LocalRotation: {x: -0.008649557, y: -0.0469462, z: -0.0062305992, w: 0.9988406}
   m_LocalPosition: {x: -0.07190759, y: 1.5543122e-17, z: 2.8607092e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1418778553}
   m_Father: {fileID: 1348790087}
@@ -35741,6 +36610,7 @@ Transform:
   m_LocalRotation: {x: 0.5562991, y: 0.41471618, z: 0.11796325, w: 0.71037066}
   m_LocalPosition: {x: -0.08505328, y: -1.6764368e-16, z: 1.1990408e-16}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 128706745}
   m_Father: {fileID: 1863663214}
@@ -35772,6 +36642,7 @@ Transform:
   m_LocalRotation: {x: -0.051588498, y: 0.5376023, z: -0.03311316, w: 0.84096724}
   m_LocalPosition: {x: -0.029250145, y: 0.026847687, z: 0.0006188383}
   m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1158576495}
   m_Father: {fileID: 15058952}
@@ -35803,6 +36674,7 @@ Transform:
   m_LocalRotation: {x: 0.00013144138, y: 0.013670122, z: 0.032817103, w: 0.9993679}
   m_LocalPosition: {x: -0.14597888, y: 2.1649348e-17, z: 2.7131074e-17}
   m_LocalScale: {x: 1.0000007, y: 1.0000002, z: 1.0000007}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1889195654}
   m_Father: {fileID: 687619508}
@@ -35834,6 +36706,7 @@ Transform:
   m_LocalRotation: {x: -0.03357769, y: 0.06963723, z: -0.014093166, w: 0.99690753}
   m_LocalPosition: {x: -0.025063124, y: 0.0014819854, z: 0.00379354}
   m_LocalScale: {x: 1, y: 0.99999994, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1337186577}
   m_Father: {fileID: 469274532}
@@ -35866,6 +36739,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 800359998}
   m_RootOrder: 6
@@ -35881,6 +36755,7 @@ SkinnedMeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
@@ -35998,6 +36873,7 @@ Transform:
   m_LocalRotation: {x: 0.1008327, y: 0.026525343, z: 0.9770472, w: 0.18576309}
   m_LocalPosition: {x: -0.033491675, y: -0.07271498, z: -0.058596842}
   m_LocalScale: {x: 1.0000008, y: 1.0000007, z: 1.0000005}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 866934120}
   m_Father: {fileID: 2045781770}
@@ -36029,6 +36905,7 @@ Transform:
   m_LocalRotation: {x: 0.00010815607, y: -0.0073533887, z: -0.05896039, w: 0.99823326}
   m_LocalPosition: {x: 0.0000000018666693, y: -0.000000030172764, z: -2.8229039e-10}
   m_LocalScale: {x: 0.99999946, y: 0.99999946, z: 0.99999964}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 712552921}
   m_Father: {fileID: 239980064}
@@ -36060,6 +36937,7 @@ Transform:
   m_LocalRotation: {x: -0.010046666, y: -0.011496983, z: -0.0012787255, w: 0.99988264}
   m_LocalPosition: {x: -0.013910712, y: 0.0000027587055, z: 0.0002477763}
   m_LocalScale: {x: 1.0000038, y: 1.000003, z: 1.0000027}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1994713067}
   m_Father: {fileID: 1074267758}


### PR DESCRIPTION
IsCurrentPlayableCompleted method works not as expected, because Playable.GetDuration returns infinity(max double?). So to solve this problem, we must set duration of playble and also we can use [Playable.IsDone](https://docs.unity3d.com/ScriptReference/Playables.PlayableExtensions.IsDone.html) istead count time by ourself.

### To Reproduce
You can see that IsCurrentPlayableCompleted always returns false for clips if you enter 2_Play_SingleClip_Dynamic scene and play not looped animation. In PlayableGraph Vizualizer edge from Animation Layer Mixer to Animation Mixer not change its weight but must cause: 
```csharp
private void LateUpdate()
{
    for (int i = 0; i < m_layerControllers.Count; i++)
    {
        m_layerControllers[i].OnPostUpdate(ref PlayableGraph);
        if (m_layerControllers[i].IsCurrentPlayableCompleted())
        {
            m_targetLayerWeight[i] = 0;
        }
        else
        {
            m_targetLayerWeight[i] = 1;
        }
    }
}
```
In AnimationMixerManager.

Clearly my fix solve this problem